### PR TITLE
[codex] Enforce context economy for core responses

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -160,8 +160,8 @@ function field(type, description, required = false) {
   return { type, description, ...(required ? { required: true } : {}) };
 }
 
-function fail(message, code, action, details) {
-  return Object.assign(new Error(message), { code, action, details, statusCode: 400 });
+function fail(message, code, nextAction, details) {
+  return Object.assign(new Error(message), { code, nextAction, details, statusCode: 400 });
 }
 
 export default defineBackendPlugin({
@@ -352,13 +352,15 @@ Throw structured errors:
 ```js
 throw Object.assign(new Error('text is required.'), {
   code: 'INVALID_PARAMS',
-  action: 'retry',
+  nextAction: 'retry',
   details: { field: 'text' },
   statusCode: 400,
 });
 ```
 
-The host forwards `error`, `code`, `action`, `details`, and HTTP `statusCode`. Good actions are short: `auth`, `retry`, `shorten`, `acquire_action_lease`, `enter_city`, `enter_location`, `fetch_detail`.
+The host forwards `error`, compact `text`, stable `code`, `nextAction`, `details`, and HTTP `statusCode`. Good next actions are short: `auth`, `retry`, `shorten`, `acquire_action_lease`, `enter_city`, `enter_location`, `fetch_detail`.
+
+Migration note for #13: current plugins may still throw `action`; the host mirrors it to `nextAction` for protocol-facing responses. New code should emit and read `nextAction`. The legacy `action` field is removed once checked-in plugins and plugin examples no longer produce it.
 
 ### Storage, events, push, lifecycle
 

--- a/docs/plugin-development.zh-CN.md
+++ b/docs/plugin-development.zh-CN.md
@@ -160,8 +160,8 @@ function field(type, description, required = false) {
   return { type, description, ...(required ? { required: true } : {}) };
 }
 
-function fail(message, code, action, details) {
-  return Object.assign(new Error(message), { code, action, details, statusCode: 400 });
+function fail(message, code, nextAction, details) {
+  return Object.assign(new Error(message), { code, nextAction, details, statusCode: 400 });
 }
 
 export default defineBackendPlugin({
@@ -352,13 +352,15 @@ protocol: {
 ```js
 throw Object.assign(new Error('text is required.'), {
   code: 'INVALID_PARAMS',
-  action: 'retry',
+  nextAction: 'retry',
   details: { field: 'text' },
   statusCode: 400,
 });
 ```
 
-host 会转发 `error`、`code`、`action`、`details` 和 HTTP `statusCode`。好的 action 很短：`auth`、`retry`、`shorten`、`acquire_action_lease`、`enter_city`、`enter_location`、`fetch_detail`。
+host 会转发 `error`、紧凑 `text`、稳定 `code`、`nextAction`、`details` 和 HTTP `statusCode`。好的 next action 很短：`auth`、`retry`、`shorten`、`acquire_action_lease`、`enter_city`、`enter_location`、`fetch_detail`。
+
+迁移说明（#13）：现有插件仍可能抛出 `action`；host 会把它镜像成协议面对的 `nextAction`。新代码应该输出并读取 `nextAction`。当仓库内插件和插件示例不再产生 `action` 后，移除这个 legacy 字段。
 
 ### Storage、events、push、lifecycle
 

--- a/packages/plugin-sdk/src/frontend.ts
+++ b/packages/plugin-sdk/src/frontend.ts
@@ -27,15 +27,18 @@ export type RuntimeListener = (payload: unknown) => void;
 
 export interface PluginCommandErrorPayload {
   error: string;
+  text?: string;
   code?: string;
   retryable?: boolean;
   action?: string;
+  nextAction?: string;
   details?: Record<string, unknown>;
 }
 
 export class PluginCommandError extends Error {
   code?: string;
   action?: string;
+  nextAction?: string;
   retryable?: boolean;
   details?: Record<string, unknown>;
 
@@ -44,6 +47,7 @@ export class PluginCommandError extends Error {
     this.name = 'PluginCommandError';
     this.code = payload.code;
     this.action = payload.action;
+    this.nextAction = payload.nextAction ?? payload.action;
     this.retryable = payload.retryable;
     this.details = payload.details;
   }
@@ -55,7 +59,7 @@ export function isPluginCommandError(error: unknown): error is PluginCommandErro
       typeof error === 'object'
       && error !== null
       && 'message' in error
-      && ('code' in error || 'retryable' in error || 'action' in error || 'details' in error)
+      && ('code' in error || 'retryable' in error || 'action' in error || 'nextAction' in error || 'details' in error)
     );
 }
 
@@ -107,6 +111,7 @@ export interface PluginSessionState {
   inCity: boolean;
   currentLocation: string | null;
   citytime: number;
+  detailRequest?: { type: string; payload?: Record<string, unknown> };
 }
 
 export interface PluginRuntimeApi extends PluginRuntimeSnapshot {

--- a/packages/server/src/core/city/__tests__/context-economy.test.ts
+++ b/packages/server/src/core/city/__tests__/context-economy.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { registerCityCommands } from '../commands.js';
+import { HookRegistry, type WSMessage } from '../../plugin-system/hook-registry.js';
+
+function createWsContext(sent: WSMessage[]) {
+  return {
+    ws: {},
+    session: {
+      userId: 'user-context-economy',
+      agentId: 'agent-context-economy',
+      agentName: 'Context Economy Agent',
+      role: 'agent' as const,
+      trustMode: 'full' as const,
+    },
+    inCity: true,
+    currentLocation: null,
+    isController: true,
+    hasController: true,
+    currentTable: null,
+    gateway: {
+      send(_ws: unknown, msg: WSMessage) {
+        sent.push(msg);
+      },
+      broadcast() {},
+      sendToAgent() {},
+      pushToOwner() {},
+      getOnlineAgentIds() {
+        return [];
+      },
+    },
+    setLocation() {},
+    setInCity() {},
+  };
+}
+
+describe('core context economy responses', () => {
+  let hooks: HookRegistry;
+  let sent: WSMessage[];
+
+  beforeEach(() => {
+    hooks = new HookRegistry();
+    registerCityCommands(hooks);
+    sent = [];
+  });
+
+  it('bounds plugin command discovery detail by default and returns the next detail request ref', async () => {
+    for (let i = 0; i < 25; i += 1) {
+      hooks.registerWSCommand(`acme.echo.command_${i}@v1`, () => undefined, {
+        type: `acme.echo.command_${i}@v1`,
+        description: `Echo command ${i}`,
+        pluginName: 'acme.echo',
+        params: {
+          text: { type: 'string', description: 'Short text to echo.' },
+        },
+        controlPolicy: { controllerRequired: false },
+      });
+    }
+
+    await hooks.handleWSCommand('what_can_i_do', createWsContext(sent) as any, {
+      id: 'discover-1',
+      type: 'what_can_i_do',
+      payload: { scope: 'plugin', pluginId: 'acme.echo' },
+    });
+
+    expect(sent.at(-1)).toMatchObject({
+      id: 'discover-1',
+      type: 'result',
+      payload: {
+        level: 'detail',
+        target: { scope: 'plugin', pluginId: 'acme.echo' },
+        page: {
+          limit: 20,
+          returned: 20,
+          total: 25,
+          nextCursor: '20',
+        },
+        nextDetailRequest: {
+          type: 'what_can_i_do',
+          payload: { scope: 'plugin', pluginId: 'acme.echo', cursor: '20', limit: 20 },
+        },
+      },
+    });
+
+    expect((sent.at(-1)?.payload as any).commands).toHaveLength(20);
+  });
+});

--- a/packages/server/src/core/city/commands.ts
+++ b/packages/server/src/core/city/commands.ts
@@ -9,7 +9,7 @@
 
 import type { HookRegistry, WSContext, WSMessage, CommandSchema } from '../plugin-system/hook-registry.js';
 import type { AgentSession } from '../../types/index.js';
-import { CORE_ERROR_CODES, resolveError } from '../server/errors.js';
+import { CORE_ERROR_CODES, compactErrorPayload, resolveError } from '../server/errors.js';
 
 const PROTOCOL_COMMANDS: CommandSchema[] = [
     {
@@ -68,7 +68,18 @@ const CITY_GATE_COMMANDS: CommandSchema[] = [
         type: 'where_can_i_go',
         description: 'List your current place and reachable locations',
         pluginName: 'core',
-        params: {},
+        params: {
+            cursor: {
+                type: 'string',
+                description: 'Optional pagination cursor from the previous response.',
+                required: false,
+            },
+            limit: {
+                type: 'number',
+                description: 'Optional page size. Defaults to 20 and is capped at 50.',
+                required: false,
+            },
+        },
         controlPolicy: { controllerRequired: false },
     },
     {
@@ -86,24 +97,76 @@ const CITY_GATE_COMMANDS: CommandSchema[] = [
                 description: 'Required when scope is "plugin".',
                 required: false,
             },
+            cursor: {
+                type: 'string',
+                description: 'Optional pagination cursor from the previous response.',
+                required: false,
+            },
+            limit: {
+                type: 'number',
+                description: 'Optional page size. Defaults to 20 and is capped at 50.',
+                required: false,
+            },
         },
         controlPolicy: { controllerRequired: false },
     },
 ];
 
 const WORLD_DESCRIPTION = 'Welcome to Uruc. This city is powered by AI agents, with multiple locations for you to explore. You are currently standing outside the city walls, where you can check your state, discover available commands, and see available destinations. When you are ready, send enter_city to begin your adventure.';
+const DEFAULT_PAGE_LIMIT = 20;
+const MAX_PAGE_LIMIT = 50;
+
+type PageInput = { limit?: unknown; cursor?: unknown };
+
+function parsePageLimit(input: PageInput): number {
+    const raw = Number(input.limit ?? DEFAULT_PAGE_LIMIT);
+    if (!Number.isFinite(raw)) return DEFAULT_PAGE_LIMIT;
+    return Math.min(MAX_PAGE_LIMIT, Math.max(1, Math.floor(raw)));
+}
+
+function parsePageOffset(input: PageInput): number {
+    if (typeof input.cursor === 'number' && Number.isFinite(input.cursor)) {
+        return Math.max(0, Math.floor(input.cursor));
+    }
+    if (typeof input.cursor === 'string' && /^\d+$/.test(input.cursor)) {
+        return Number(input.cursor);
+    }
+    return 0;
+}
+
+function paginate<T>(items: T[], input: PageInput): { items: T[]; page: Record<string, unknown>; nextCursor?: string } {
+    const limit = parsePageLimit(input);
+    const offset = parsePageOffset(input);
+    const pageItems = items.slice(offset, offset + limit);
+    const nextOffset = offset + pageItems.length;
+    const nextCursor = nextOffset < items.length ? String(nextOffset) : undefined;
+    return {
+        items: pageItems,
+        page: {
+            limit,
+            returned: pageItems.length,
+            total: items.length,
+            ...(nextCursor ? { nextCursor } : {}),
+        },
+        nextCursor,
+    };
+}
 
 function attachCitytime(payload: unknown): unknown {
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
         return payload;
     }
 
+    const base = ('error' in (payload as Record<string, unknown>) && 'code' in (payload as Record<string, unknown>))
+        ? compactErrorPayload(payload as any)
+        : payload as Record<string, unknown>;
+
     if ('citytime' in (payload as Record<string, unknown>)) {
-        return payload;
+        return base;
     }
 
     return {
-        ...(payload as Record<string, unknown>),
+        ...base,
         citytime: Date.now(),
     };
 }
@@ -315,19 +378,28 @@ export function registerCityCommands(hooks: HookRegistry) {
 
     // --- where_can_i_go ---
     hooks.registerWSCommand('where_can_i_go', async (ctx: WSContext, msg: WSMessage) => {
+        const payload = (msg.payload && typeof msg.payload === 'object') ? msg.payload as PageInput : {};
+        const page = paginate(getAccessibleLocations(ctx, hooks), payload);
         sendCore(ctx, {
             id: msg.id,
             type: 'result',
             payload: {
                 current: buildCurrentPlace(ctx, hooks),
-                locations: getAccessibleLocations(ctx, hooks),
+                locations: page.items,
+                page: page.page,
+                ...(page.nextCursor ? {
+                    nextDetailRequest: {
+                        type: 'where_can_i_go',
+                        payload: { cursor: page.nextCursor, limit: page.page.limit },
+                    },
+                } : {}),
             },
         });
     }, CITY_GATE_COMMANDS[4]);
 
     // --- what_can_i_do ---
     hooks.registerWSCommand('what_can_i_do', async (ctx: WSContext, msg: WSMessage) => {
-        const payload = (msg.payload && typeof msg.payload === 'object') ? msg.payload as { scope?: string; pluginId?: string } : {};
+        const payload = (msg.payload && typeof msg.payload === 'object') ? msg.payload as { scope?: string; pluginId?: string } & PageInput : {};
         const { scope, pluginId } = payload;
         const cityCommands = getCityCommandSchemas(ctx, hooks);
         const pluginGroups = getPluginCommandGroups(ctx, hooks);
@@ -349,18 +421,26 @@ export function registerCityCommands(hooks: HookRegistry) {
                     commandCount: commands.length,
                 });
             }
+            const page = paginate(groups, payload);
 
             sendCore(ctx, {
                 id: msg.id,
                 type: 'result',
                 payload: {
                     level: 'summary',
-                    groups,
-                    detailQueries: groups.map((group) => (
+                    groups: page.items,
+                    page: page.page,
+                    detailQueries: page.items.map((group) => (
                         group.scope === 'city'
                             ? { scope: 'city' }
                             : { scope: 'plugin', pluginId: group.pluginId }
                     )),
+                    ...(page.nextCursor ? {
+                        nextDetailRequest: {
+                            type: 'what_can_i_do',
+                            payload: { cursor: page.nextCursor, limit: page.page.limit },
+                        },
+                    } : {}),
                     hint: 'Pass one of detailQueries back to what_can_i_do for full command schemas.',
                 },
             });
@@ -368,13 +448,21 @@ export function registerCityCommands(hooks: HookRegistry) {
         }
 
         if (scope === 'city') {
+            const page = paginate(cityCommands, payload);
             sendCore(ctx, {
                 id: msg.id,
                 type: 'result',
                 payload: {
                     level: 'detail',
                     target: { scope: 'city' },
-                    commands: cityCommands,
+                    commands: page.items,
+                    page: page.page,
+                    ...(page.nextCursor ? {
+                        nextDetailRequest: {
+                            type: 'what_can_i_do',
+                            payload: { scope: 'city', cursor: page.nextCursor, limit: page.page.limit },
+                        },
+                    } : {}),
                 },
             });
             return;
@@ -406,13 +494,21 @@ export function registerCityCommands(hooks: HookRegistry) {
                 return;
             }
 
+            const page = paginate(commands, payload);
             sendCore(ctx, {
                 id: msg.id,
                 type: 'result',
                 payload: {
                     level: 'detail',
                     target: { scope: 'plugin', pluginId },
-                    commands,
+                    commands: page.items,
+                    page: page.page,
+                    ...(page.nextCursor ? {
+                        nextDetailRequest: {
+                            type: 'what_can_i_do',
+                            payload: { scope: 'plugin', pluginId, cursor: page.nextCursor, limit: page.page.limit },
+                        },
+                    } : {}),
                 },
             });
             return;

--- a/packages/server/src/core/plugin-platform/host.ts
+++ b/packages/server/src/core/plugin-platform/host.ts
@@ -8,6 +8,7 @@ import { nanoid } from 'nanoid';
 import { sql } from 'drizzle-orm';
 
 import { parseBody, sendError, sendJson } from '../server/middleware.js';
+import { compactErrorPayload } from '../server/errors.js';
 import { setCorsHeaders, setSecurityHeaders } from '../server/security.js';
 import type {
   HttpContext,
@@ -1257,10 +1258,14 @@ export class PluginPlatformHost implements PluginPlatformHealthProvider {
           id: msg.id,
           type: 'error',
           payload: {
-            error: error?.message ?? error?.error ?? 'Plugin command failed',
-            code: error?.code ?? 'PLUGIN_COMMAND_FAILED',
-            action: error?.action,
-            details: error?.details,
+            ...compactErrorPayload({
+              error: error?.message ?? error?.error ?? 'Plugin command failed',
+              code: error?.code ?? 'PLUGIN_COMMAND_FAILED',
+              action: error?.action,
+              nextAction: error?.nextAction,
+              details: error?.details,
+            }),
+            citytime: Date.now(),
           },
         });
       } finally {
@@ -1329,6 +1334,7 @@ export class PluginPlatformHost implements PluginPlatformHealthProvider {
           error: error?.message ?? error?.error ?? 'Plugin route failed',
           code: error?.code ?? 'PLUGIN_ROUTE_FAILED',
           action: error?.action,
+          nextAction: error?.nextAction,
           details: error?.details,
         }, httpCtx.req);
       } finally {

--- a/packages/server/src/core/plugin-system/hook-registry.ts
+++ b/packages/server/src/core/plugin-system/hook-registry.ts
@@ -70,12 +70,16 @@ export type WSHandler = (ctx: WSContext, msg: WSMessage) => Promise<void> | void
 export interface WSErrorPayload {
   /** Human-readable error message */
   error: string;
+  /** Concise protocol-facing text for resident receipts */
+  text?: string;
   /** Stable machine-readable code (e.g. 'RATE_LIMITED', 'UNKNOWN_COMMAND') */
   code: string;
   /** Whether the client can retry this request */
   retryable?: boolean;
   /** Suggested next action for recovering (e.g. 'auth', 'leave_location') */
   action?: string;
+  /** Protocol-facing next action. `action` remains for current runtime clients until consumer migration is complete. */
+  nextAction?: string;
   /** Additional structured details */
   details?: Record<string, unknown>;
 }

--- a/packages/server/src/core/server/__tests__/ws-error-codes.test.ts
+++ b/packages/server/src/core/server/__tests__/ws-error-codes.test.ts
@@ -105,6 +105,31 @@ describe('WS core error codes', () => {
     expect(sent.at(-1)?.payload?.code).toBe('UNKNOWN_COMMAND');
   });
 
+  it('returns compact receipt-style metadata for unauthenticated websocket commands', async () => {
+    const sent: SentEnvelope[] = [];
+    const client = createClient(sent);
+
+    (gateway as any).clients.set('client-unauthenticated', client);
+
+    await (gateway as any).handleMessage('client-unauthenticated', {
+      id: 'cmd-unauthenticated',
+      type: 'what_can_i_do',
+      payload: {},
+    });
+
+    expect(sent.at(-1)).toMatchObject({
+      id: 'cmd-unauthenticated',
+      type: 'error',
+      payload: {
+        code: 'NOT_AUTHENTICATED',
+        error: 'Not authenticated. Send auth message first.',
+        text: 'Not authenticated. Send auth message first.',
+        nextAction: 'auth',
+        citytime: expect.any(Number),
+      },
+    });
+  });
+
   it('returns BAD_REQUEST when enter_location is missing locationId', async () => {
     const user = await auth.register('enkidu', 'enkidu@example.com', 'secret123');
     const sent: SentEnvelope[] = [];

--- a/packages/server/src/core/server/__tests__/ws-gateway-control.test.ts
+++ b/packages/server/src/core/server/__tests__/ws-gateway-control.test.ts
@@ -17,7 +17,7 @@ interface SentEnvelope {
   type: string;
   payload?: {
     citytime?: number;
-    claimed?: boolean;
+    actionLeaseAcquired?: boolean;
     current?: {
       place?: string;
       locationId?: string | null;
@@ -28,6 +28,7 @@ interface SentEnvelope {
     inCity?: boolean;
     error?: string;
     locations?: Array<{ id: string; name: string }>;
+    detailRequest?: { type: string; payload?: Record<string, unknown> };
   };
 }
 
@@ -95,6 +96,9 @@ describe('WSGateway control connection', () => {
     expect(sentA.some((message) => message.type === 'result' && message.payload?.inCity === true)).toBe(true);
     expect(sentA.some((message) => message.type === 'session_state')).toBe(false);
     expect(sentB.some((message) => message.type === 'session_state' && message.payload?.inCity === true)).toBe(true);
+    expect(sentB.find((message) => message.type === 'session_state' && message.payload?.inCity === true)?.payload).toMatchObject({
+      detailRequest: { type: 'what_state_am_i' },
+    });
 
     await (gateway as any).handleMessage('client-b', {
       id: 'enter-location-b',
@@ -168,11 +172,11 @@ describe('WSGateway control connection', () => {
     await (gateway as any).handleMessage('client-a', { id: 'enter-a', type: 'enter_city', payload: {} });
     await (gateway as any).handleMessage('client-b', { id: 'lease-b', type: 'acquire_action_lease', payload: {} });
 
-    expect(sentA.some((message) => message.type === 'control_replaced')).toBe(true);
+    expect(sentA.some((message) => message.type === 'action_lease_moved')).toBe(true);
     expect(clientA.ws.close).not.toHaveBeenCalled();
     expect(sentB.some((message) => message.type === 'control_claimed')).toBe(false);
     expect(sentB.find((message) => message.type === 'result')?.payload).toMatchObject({
-      claimed: true,
+      actionLeaseAcquired: true,
       restored: false,
     });
   });
@@ -307,9 +311,11 @@ describe('WSGateway control connection', () => {
     await (gateway as any).handleMessage('client-a', { id: 'enter-a', type: 'enter_city', payload: {} });
     await (gateway as any).handleMessage('client-b', { id: 'lease-b', type: 'acquire_action_lease', payload: {} });
 
-    expect(sentA.find((message) => message.type === 'control_replaced')?.payload).toMatchObject({
+    expect(sentA.find((message) => message.type === 'action_lease_moved')?.payload).toMatchObject({
       citytime: expect.any(Number),
       error: 'This resident action lease moved to another session.',
+      nextAction: 'acquire_action_lease',
+      detailRequest: { type: 'what_state_am_i' },
     });
   });
 });

--- a/packages/server/src/core/server/errors.ts
+++ b/packages/server/src/core/server/errors.ts
@@ -28,6 +28,7 @@ export interface AppErrorOptions {
   status?: number;
   retryable?: boolean;
   action?: string;
+  nextAction?: string;
   details?: Record<string, unknown>;
 }
 
@@ -36,6 +37,7 @@ export class AppError extends Error {
   readonly status: number;
   readonly retryable?: boolean;
   readonly action?: string;
+  readonly nextAction?: string;
   readonly details?: Record<string, unknown>;
 
   constructor(opts: AppErrorOptions) {
@@ -45,6 +47,7 @@ export class AppError extends Error {
     this.status = opts.status ?? 400;
     this.retryable = opts.retryable;
     this.action = opts.action;
+    this.nextAction = opts.nextAction;
     this.details = opts.details;
   }
 }
@@ -58,6 +61,7 @@ type ErrorLikePayload = {
   status?: number;
   retryable?: boolean;
   action?: string;
+  nextAction?: string;
   details?: Record<string, unknown>;
 };
 
@@ -68,6 +72,7 @@ function isErrorLikePayload(error: unknown): error is Error & ErrorLikePayload {
       || typeof (error as ErrorLikePayload).status === 'number'
       || typeof (error as ErrorLikePayload).retryable === 'boolean'
       || typeof (error as ErrorLikePayload).action === 'string'
+      || typeof (error as ErrorLikePayload).nextAction === 'string'
       || typeof (error as ErrorLikePayload).details === 'object'
     );
 }
@@ -93,6 +98,15 @@ export function codeForStatus(status: number): string {
   }
 }
 
+export function compactErrorPayload(payload: WSErrorPayload): WSErrorPayload {
+  const nextAction = payload.nextAction ?? payload.action;
+  return {
+    ...payload,
+    text: payload.text ?? payload.error,
+    ...(nextAction !== undefined ? { nextAction } : {}),
+  };
+}
+
 export function resolveError(
   error: unknown,
   fallback: ErrorFallback,
@@ -100,13 +114,14 @@ export function resolveError(
   if (isAppError(error)) {
     return {
       status: error.status,
-      payload: {
+      payload: compactErrorPayload({
         error: error.message,
         code: error.code,
         ...(error.retryable !== undefined ? { retryable: error.retryable } : {}),
         ...(error.action !== undefined ? { action: error.action } : {}),
+        ...(error.nextAction !== undefined ? { nextAction: error.nextAction } : {}),
         ...(error.details !== undefined ? { details: error.details } : {}),
-      },
+      }),
     };
   }
 
@@ -114,37 +129,40 @@ export function resolveError(
     if (isErrorLikePayload(error)) {
       return {
         status: typeof error.status === 'number' ? error.status : fallback.status,
-        payload: {
+        payload: compactErrorPayload({
           error: error.message,
           code: error.code ?? fallback.code,
           ...((error.retryable ?? fallback.retryable) !== undefined ? { retryable: error.retryable ?? fallback.retryable } : {}),
           ...((error.action ?? fallback.action) !== undefined ? { action: error.action ?? fallback.action } : {}),
+          ...((error.nextAction ?? fallback.nextAction) !== undefined ? { nextAction: error.nextAction ?? fallback.nextAction } : {}),
           ...((error.details ?? fallback.details) !== undefined ? { details: error.details ?? fallback.details } : {}),
-        },
+        }),
       };
     }
 
     return {
       status: fallback.status,
-      payload: {
+      payload: compactErrorPayload({
         error: error.message,
         code: fallback.code,
         ...(fallback.retryable !== undefined ? { retryable: fallback.retryable } : {}),
         ...(fallback.action !== undefined ? { action: fallback.action } : {}),
+        ...(fallback.nextAction !== undefined ? { nextAction: fallback.nextAction } : {}),
         ...(fallback.details !== undefined ? { details: fallback.details } : {}),
-      },
+      }),
     };
   }
 
   return {
     status: fallback.status,
-    payload: {
+    payload: compactErrorPayload({
       error: fallback.error,
       code: fallback.code,
       ...(fallback.retryable !== undefined ? { retryable: fallback.retryable } : {}),
       ...(fallback.action !== undefined ? { action: fallback.action } : {}),
+      ...(fallback.nextAction !== undefined ? { nextAction: fallback.nextAction } : {}),
       ...(fallback.details !== undefined ? { details: fallback.details } : {}),
-    },
+    }),
   };
 }
 

--- a/packages/server/src/core/server/middleware.ts
+++ b/packages/server/src/core/server/middleware.ts
@@ -124,10 +124,23 @@ export function sendJson(res: ServerResponse, status: number, data: any, req?: I
 
 export function sendError(
   res: ServerResponse, status: number,
-  opts: { error: string; code: string; retryable?: boolean; action?: string; details?: Record<string, unknown> },
+  opts: {
+    error: string;
+    text?: string;
+    code: string;
+    retryable?: boolean;
+    action?: string;
+    nextAction?: string;
+    details?: Record<string, unknown>;
+  },
   req?: IncomingMessage,
 ) {
-  sendJson(res, status, opts, req);
+  const nextAction = opts.nextAction ?? opts.action;
+  sendJson(res, status, {
+    ...opts,
+    text: opts.text ?? opts.error,
+    ...(nextAction !== undefined ? { nextAction } : {}),
+  }, req);
 }
 
 export function getAuthUser(req: IncomingMessage): { userId: string; role: string } | null {

--- a/packages/server/src/core/server/ws-gateway.ts
+++ b/packages/server/src/core/server/ws-gateway.ts
@@ -22,7 +22,7 @@ import type { AuthService } from '../auth/service.js';
 import type { AgentSession, WSMessage } from '../../types/index.js';
 import { getCookieAuthUser, verifyToken } from './middleware.js';
 import { AgentSessionService, type AgentSessionSnapshot } from './agent-session-service.js';
-import { AppError, CORE_ERROR_CODES, resolveError } from './errors.js';
+import { AppError, CORE_ERROR_CODES, compactErrorPayload, resolveError } from './errors.js';
 
 /**
  * Typed interface for admin operations on the gateway.
@@ -294,13 +294,13 @@ export class WSGateway implements WSGatewayPublic {
       return this.handleStateQuery(clientId, client, msg);
     }
 
-    // `claim_control` is kept as a hidden compatibility alias for existing web runtimes.
-    // Discovery exposes acquire_action_lease; remove the alias after clients migrate.
+    // Hidden compatibility alias for pre-action-lease clients. Discovery only exposes
+    // acquire_action_lease; remove this after issue #8 migrates checked-in clients.
     if (msg.type === 'acquire_action_lease' || msg.type === 'claim_control') {
       return this.handleClaimControl(clientId, client, msg);
     }
 
-    // `release_control` follows the same temporary compatibility path as claim_control.
+    // Hidden compatibility alias for pre-action-lease clients; same removal target as above.
     if (msg.type === 'release_action_lease' || msg.type === 'release_control') {
       return this.handleReleaseControl(clientId, client, msg);
     }
@@ -470,11 +470,13 @@ export class WSGateway implements WSGatewayPublic {
       if (replaced) {
         this.sendCore(replaced.ws, {
           id: '',
-          type: 'control_replaced',
+          type: 'action_lease_moved',
           payload: {
             ...this.buildSessionState(client.session.agentId, result.replacedConnectionId),
             error: 'This resident action lease moved to another session.',
             agentId: client.session.agentId,
+            nextAction: 'acquire_action_lease',
+            detailRequest: { type: 'what_state_am_i' },
           },
         });
       }
@@ -486,7 +488,6 @@ export class WSGateway implements WSGatewayPublic {
       payload: {
         ...this.buildSessionState(client.session.agentId, clientId),
         actionLeaseAcquired: true,
-        claimed: true,
         restored: result.restored,
       },
     });
@@ -560,7 +561,14 @@ export class WSGateway implements WSGatewayPublic {
     for (const [clientId, client] of this.clients) {
       if (client.session?.agentId !== agentId) continue;
       if (excludedClientId && clientId === excludedClientId) continue;
-      this.sendCore(client.ws, { id: '', type: 'session_state', payload: this.buildSessionState(agentId, clientId) });
+      this.sendCore(client.ws, {
+        id: '',
+        type: 'session_state',
+        payload: {
+          ...this.buildSessionState(agentId, clientId),
+          detailRequest: { type: 'what_state_am_i' },
+        },
+      });
     }
   }
 
@@ -635,12 +643,16 @@ export class WSGateway implements WSGatewayPublic {
       return payload;
     }
 
+    const base = ('error' in (payload as Record<string, unknown>) && 'code' in (payload as Record<string, unknown>))
+      ? compactErrorPayload(payload as any)
+      : payload as Record<string, unknown>;
+
     if ('citytime' in (payload as Record<string, unknown>)) {
-      return payload;
+      return base;
     }
 
     return {
-      ...(payload as Record<string, unknown>),
+      ...base,
       citytime: Date.now(),
     };
   }

--- a/packages/web/src/context/AgentRuntimeContext.tsx
+++ b/packages/web/src/context/AgentRuntimeContext.tsx
@@ -143,7 +143,9 @@ export function AgentRuntimeProvider({ children }: { children: React.ReactNode }
           pushEvent(i18n.t('runtime:websocket.commandRejectedPrefix', { message: payload.error }));
         }
       }
-      if (envelope.type === 'control_replaced') {
+      // `control_replaced` is a hidden compatibility read path for servers older than
+      // issue #13. Remove it once deployed servers emit action_lease_moved only.
+      if (envelope.type === 'action_lease_moved' || envelope.type === 'control_replaced') {
         const payload = envelope.payload as { error?: string } | undefined;
         const text = payload?.error ?? i18n.t('runtime:websocket.controlReplaced');
         pushEvent(text);

--- a/packages/web/src/lib/__tests__/runtime-broker-core.test.ts
+++ b/packages/web/src/lib/__tests__/runtime-broker-core.test.ts
@@ -206,6 +206,49 @@ describe('SharedRuntimeBrokerCore', () => {
     });
   });
 
+  it('applies action lease movement pushes to the shared runtime state', async () => {
+    const clientA = attachClient(core, 'client-a');
+    const clientB = attachClient(core, 'client-b');
+
+    await core.handleMessage('client-a', {
+      kind: 'connect',
+      requestId: 'connect-a',
+      url: 'ws://127.0.0.1:3001',
+    });
+
+    clientA.length = 0;
+    clientB.length = 0;
+
+    socket.emitMessage({
+      id: '',
+      type: 'action_lease_moved',
+      payload: {
+        hasController: true,
+        isController: false,
+        inCity: true,
+        currentLocation: 'uruc.chess.chess-club',
+        citytime: 789,
+        error: 'This resident action lease moved to another session.',
+      },
+    });
+
+    expect(getLastSnapshot(clientA)).toMatchObject({
+      kind: 'snapshot',
+      state: {
+        isController: false,
+        error: 'This resident action lease moved to another session.',
+        currentLocation: 'uruc.chess.chess-club',
+      },
+    });
+    expect(getLastSnapshot(clientB)).toMatchObject({
+      kind: 'snapshot',
+      state: {
+        isController: false,
+        error: 'This resident action lease moved to another session.',
+      },
+    });
+  });
+
   it('disconnects only after the idle timeout and cancels the timer when another client reattaches', async () => {
     vi.useFakeTimers();
     const clientA = attachClient(core, 'client-a');

--- a/packages/web/src/lib/runtime-broker-core.ts
+++ b/packages/web/src/lib/runtime-broker-core.ts
@@ -28,6 +28,7 @@ function serializeTransportError(error: unknown): SerializedTransportError {
     const typed = error as Error & {
       code?: string;
       action?: string;
+      nextAction?: string;
       retryable?: boolean;
       details?: Record<string, unknown>;
     };
@@ -36,6 +37,7 @@ function serializeTransportError(error: unknown): SerializedTransportError {
       name: error.name,
       code: typed.code,
       action: typed.action,
+      nextAction: typed.nextAction,
       retryable: typed.retryable,
       details: typed.details,
     };
@@ -242,7 +244,9 @@ export class SharedRuntimeBrokerCore {
       return;
     }
 
-    if (envelope.type === 'control_replaced') {
+    // `control_replaced` is a hidden compatibility read path for servers older than
+    // issue #13. Remove it once deployed servers emit action_lease_moved only.
+    if (envelope.type === 'action_lease_moved' || envelope.type === 'control_replaced') {
       applyRuntimePatch(this.state, envelope.payload);
       const payload = envelope.payload as { error?: string } | undefined;
       this.state.isController = false;

--- a/packages/web/src/lib/runtime-broker-protocol.ts
+++ b/packages/web/src/lib/runtime-broker-protocol.ts
@@ -27,6 +27,7 @@ export interface SerializedTransportError {
   name?: string;
   code?: string;
   action?: string;
+  nextAction?: string;
   retryable?: boolean;
   details?: Record<string, unknown>;
 }

--- a/packages/web/src/lib/runtime-transport.ts
+++ b/packages/web/src/lib/runtime-transport.ts
@@ -108,11 +108,12 @@ class UnavailableRuntimeTransport implements RuntimeTransport {
 }
 
 function toWsCommandError(error: SerializedTransportError): Error {
-  if (error.code || error.action || error.retryable !== undefined || error.details || error.name === 'WsCommandError') {
+  if (error.code || error.action || error.nextAction || error.retryable !== undefined || error.details || error.name === 'WsCommandError') {
     return new WsCommandError({
       error: error.message,
       code: error.code,
       action: error.action,
+      nextAction: error.nextAction,
       retryable: error.retryable,
       details: error.details,
     } satisfies WsErrorPayload);
@@ -253,7 +254,9 @@ class DirectRuntimeTransport implements RuntimeTransport {
       return;
     }
 
-    if (envelope.type === 'control_replaced') {
+    // `control_replaced` is a hidden compatibility read path for servers older than
+    // issue #13. Remove it once deployed servers emit action_lease_moved only.
+    if (envelope.type === 'action_lease_moved' || envelope.type === 'control_replaced') {
       applyRuntimePatch(this.state, envelope.payload);
       const payload = envelope.payload as { error?: string } | undefined;
       this.state.isController = false;

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -108,9 +108,11 @@ export type WsConnectionStatus =
 
 export interface WsErrorPayload {
   error: string;
+  text?: string;
   code?: string;
   retryable?: boolean;
   action?: string;
+  nextAction?: string;
   details?: Record<string, unknown>;
 }
 
@@ -127,11 +129,29 @@ export interface RuntimeSnapshot {
   inCity: boolean;
   currentLocation: string | null;
   citytime: number;
+  detailRequest?: DetailRequestRef;
+}
+
+export interface PaginationInfo {
+  limit: number;
+  returned: number;
+  total: number;
+  nextCursor?: string;
+}
+
+export interface DetailRequestRef<TPayload = Record<string, unknown>> {
+  type: string;
+  payload?: TPayload;
+}
+
+export interface DiscoveryPageParams {
+  cursor?: string;
+  limit?: number;
 }
 
 export type CommandDiscoveryQuery =
-  | { scope: 'city' }
-  | { scope: 'plugin'; pluginId: string };
+  | ({ scope: 'city' } & DiscoveryPageParams)
+  | ({ scope: 'plugin'; pluginId: string } & DiscoveryPageParams);
 
 export interface CommandDiscoveryGroup {
   scope: 'city' | 'plugin';
@@ -145,6 +165,8 @@ export interface CommandDiscoverySummary {
   level: 'summary';
   groups: CommandDiscoveryGroup[];
   detailQueries: CommandDiscoveryQuery[];
+  page?: PaginationInfo;
+  nextDetailRequest?: DetailRequestRef<DiscoveryPageParams>;
   hint: string;
 }
 
@@ -153,6 +175,8 @@ export interface CommandDiscoveryDetail {
   level: 'detail';
   target: CommandDiscoveryQuery;
   commands: CommandSchema[];
+  page?: PaginationInfo;
+  nextDetailRequest?: DetailRequestRef<CommandDiscoveryQuery>;
 }
 
 export type CommandDiscoveryResponse = CommandDiscoverySummary | CommandDiscoveryDetail;
@@ -167,4 +191,6 @@ export interface LocationDiscoveryResult {
   citytime: number;
   current: LocationDiscoveryCurrent;
   locations: LocationDef[];
+  page?: PaginationInfo;
+  nextDetailRequest?: DetailRequestRef<DiscoveryPageParams>;
 }


### PR DESCRIPTION
## Summary

Closes #13.

- Adds compact core response metadata with stable codes, concise text, refs, and `nextAction` where useful.
- Bounds/disciplines core discovery/status response shapes and sparse push/error paths.
- Updates runtime-facing types and docs for context-economy response expectations.
- Adds focused tests for a core discovery/status response and error/receipt path.

## Checks run

- `npm run test --workspace=packages/server -- src/core/city/__tests__/context-economy.test.ts src/core/server/__tests__/ws-error-codes.test.ts src/core/server/__tests__/ws-gateway-control.test.ts`
- `npm run docs:check`
- `npm run test --workspace=packages/web -- src/lib/__tests__/runtime-broker-core.test.ts`

## Notes

- Full server suite was not rerun here; issue #2 documented the existing `src/__tests__/publish-packages.test.ts` timeout where `npm pack --dry-run` takes about 64 seconds while the test timeout is 30 seconds.