### PR TITLE
feat: add venue topology declaration

### DIFF
--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -303,6 +303,7 @@ Current city config contents include:
 - `pluginStoreDir`
 - `sources`
 - configured venue package specs
+- optional per-venue topology selection (`local` or `domain`)
 
 Current city lock contents include resolved venue package runtime data such as:
 
@@ -310,6 +311,7 @@ Current city lock contents include resolved venue package runtime data such as:
 - version
 - publisher
 - venue module metadata, including module id and namespace
+- compact topology metadata: declaration, selected runtime mode, and optional domain endpoint/document hints
 - package root
 - entry path
 - dependencies
@@ -331,6 +333,8 @@ Current city lock contents include resolved venue package runtime data such as:
 - records diagnostics for active and failed plugins
 
 Failed venue modules are retained in diagnostics even when they do not become active.
+
+Topology support is declaration-only in this slice. Local modules stay local by default. Domain-capable modules can expose endpoint/document hints and city config can select domain runtime mode, but the host does not perform Domain Document fetch, attachment handshake, signed envelope dispatch, federation, or venue business synchronization.
 
 ### Runtime context exposed to backend venue modules
 

--- a/docs/core-architecture.zh-CN.md
+++ b/docs/core-architecture.zh-CN.md
@@ -303,6 +303,7 @@ Venue Module 包宿主当前使用两个文件：
 - `pluginStoreDir`
 - `sources`
 - 已配置场馆包规格
+- 可选的 per-venue topology selection（`local` 或 `domain`）
 
 当前 city lock 包含的已解析场馆包运行时信息包括：
 
@@ -310,6 +311,7 @@ Venue Module 包宿主当前使用两个文件：
 - version
 - publisher
 - Venue Module metadata，包括 module id 和 namespace
+- 紧凑 topology metadata：declaration、已选择 runtime mode，以及可选 domain endpoint/document hints
 - package root
 - entry path
 - dependencies
@@ -331,6 +333,8 @@ Venue Module 包宿主当前使用两个文件：
 - 为 active 和 failed Venue Module 记录诊断
 
 即使 Venue Module 没有进入 active 状态，失败信息仍会保留在 diagnostics 中。
+
+本 slice 的 topology 只是声明。Local module 默认保持 local。Domain-capable module 可以暴露 endpoint/document hints，city config 可以选择 domain runtime mode，但 host 不会执行 Domain Document 拉取、attachment handshake、signed envelope dispatch、federation 或 Venue 业务同步。
 
 ### 后端 Venue Module 可见的运行时上下文
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -112,7 +112,10 @@ Backend venue modules are ESM packages with the current `package.json#urucPlugin
       "moduleId": "acme.echo",
       "namespace": "acme.echo",
       "displayName": "Echo",
-      "description": "A small Echo venue module."
+      "description": "A small Echo venue module.",
+      "topology": {
+        "mode": "local"
+      }
     },
     "permissions": [],
     "dependencies": [],
@@ -141,6 +144,11 @@ Venue metadata:
 | `venue.displayName` | Human-facing venue module name |
 | `venue.description` | Short public description of the venue module |
 | `venue.category` | Optional category such as `communication`, `game`, `market`, or `public space` |
+| `venue.topology.mode` | `local`, `domain_optional`, or `domain_required`; omitted metadata defaults to local |
+| `venue.topology.domain.endpoint` | Optional domain endpoint hint for domain-capable modules |
+| `venue.topology.domain.document` | Optional Domain Document URL hint; the handshake itself is not implemented in this slice |
+
+City config may select runtime topology with `plugins[pluginId].topology.mode` as `local` or `domain`. `domain_optional` modules default to local unless city config selects domain. `domain_required` modules fail resolution until city config selects domain. This declaration does not perform a network call or domain handshake.
 
 Useful optional fields:
 

--- a/docs/plugin-development.zh-CN.md
+++ b/docs/plugin-development.zh-CN.md
@@ -112,7 +112,10 @@ packages/server/uruc.city.json
       "moduleId": "acme.echo",
       "namespace": "acme.echo",
       "displayName": "Echo",
-      "description": "A small Echo venue module."
+      "description": "A small Echo venue module.",
+      "topology": {
+        "mode": "local"
+      }
     },
     "permissions": [],
     "dependencies": [],
@@ -141,6 +144,11 @@ Venue metadata：
 | `venue.displayName` | 面向人类的 Venue Module 名称 |
 | `venue.description` | Venue Module 的简短公开描述 |
 | `venue.category` | 可选分类，例如 `communication`、`game`、`market` 或 `public space` |
+| `venue.topology.mode` | `local`、`domain_optional` 或 `domain_required`；未声明时默认 local |
+| `venue.topology.domain.endpoint` | domain-capable module 的可选 Domain endpoint hint |
+| `venue.topology.domain.document` | 可选 Domain Document URL hint；本 slice 不实现 handshake |
+
+City config 可以通过 `plugins[pluginId].topology.mode` 选择 `local` 或 `domain` runtime topology。`domain_optional` 默认 local，除非 city config 选择 domain。`domain_required` 在 city config 选择 domain 前会解析失败。该声明不会发起网络请求或 domain handshake。
 
 常用可选字段：
 

--- a/packages/plugin-sdk/src/backend.ts
+++ b/packages/plugin-sdk/src/backend.ts
@@ -27,12 +27,24 @@ export const pluginHealthcheckSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
 });
 
+export const venueTopologyDeclarationSchema = z.enum(['local', 'domain_optional', 'domain_required']);
+export const venueRuntimeTopologyModeSchema = z.enum(['local', 'domain']);
+
+export const venueTopologySchema = z.object({
+  mode: venueTopologyDeclarationSchema,
+  domain: z.object({
+    endpoint: z.string().min(1).optional(),
+    document: z.string().min(1).optional(),
+  }).optional(),
+});
+
 export const venueModuleMetadataSchema = z.object({
   moduleId: z.string().min(1).optional(),
   namespace: z.string().min(1).optional(),
   displayName: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
   category: z.string().min(1).optional(),
+  topology: venueTopologySchema.optional(),
 });
 
 export const pluginMigrationSchema = z.object({
@@ -60,6 +72,9 @@ export const backendPluginManifestSchema = z.object({
 
 export type BackendPluginManifest = z.infer<typeof backendPluginManifestSchema>;
 export type VenueModuleMetadata = z.infer<typeof venueModuleMetadataSchema>;
+export type VenueTopologyDeclaration = z.infer<typeof venueTopologyDeclarationSchema>;
+export type VenueRuntimeTopologyMode = z.infer<typeof venueRuntimeTopologyModeSchema>;
+export type VenueTopology = z.infer<typeof venueTopologySchema>;
 
 export const authPolicySchema = z.enum(['agent', 'user', 'admin']);
 export const locationScopeSchema = z.enum(['any', 'outside', 'city', 'in-city', 'location']);

--- a/packages/server/src/core/plugin-platform/__tests__/host.test.ts
+++ b/packages/server/src/core/plugin-platform/__tests__/host.test.ts
@@ -957,6 +957,98 @@ export default {
     await host.stopAll();
   });
 
+  it('does not let city config override venue domain metadata from the package manifest', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-override-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'domain-topology-override');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.domain-override',
+      packageName: '@acme/plugin-domain-override',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.domain-override',
+        namespace: 'acme.domain-override',
+        topology: {
+          mode: 'domain_optional',
+          domain: {
+            endpoint: 'https://domain.example/acme',
+            document: 'https://domain.example/.well-known/uruc-domain.json',
+          },
+        },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.domain-override': {
+          pluginId: 'acme.domain-override',
+          packageName: '@acme/plugin-domain-override',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+          topology: {
+            mode: 'domain',
+            domain: {
+              endpoint: 'https://city-config.example/override',
+              document: 'https://city-config.example/override-document.json',
+            },
+          } as { mode: 'domain' },
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    const lock = await readCityLock(lockPath);
+    expect(lock.plugins['acme.domain-override']?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        endpoint: 'https://domain.example/acme',
+        document: 'https://domain.example/.well-known/uruc-domain.json',
+      },
+    });
+
+    const hooks = new HookRegistry();
+    const services = new ServiceRegistry();
+    const db = createDb(':memory:');
+    await host.startAll({ db, hooks, services });
+
+    expect(host.listPlugins().find((item) => item.name === 'acme.domain-override')?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        endpoint: 'https://domain.example/acme',
+        document: 'https://domain.example/.well-known/uruc-domain.json',
+      },
+    });
+    expect(host.getPluginDiagnostics().find((item) => item.pluginId === 'acme.domain-override')?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        endpoint: 'https://domain.example/acme',
+        document: 'https://domain.example/.well-known/uruc-domain.json',
+      },
+    });
+
+    await host.stopAll();
+  });
+
   it('keeps a domain-optional venue local when city config selects local mode', async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-local-'));
     tempDirs.push(tempRoot);
@@ -1107,10 +1199,7 @@ export default {
           enabled: true,
           permissionsGranted: [],
           devOverridePath: pluginPath,
-          topology: {
-            mode: 'domain',
-            domain: { endpoint: 'https://domain.example/acme-unsupported' },
-          },
+          topology: { mode: 'domain' },
         },
       },
     });

--- a/packages/server/src/core/plugin-platform/__tests__/host.test.ts
+++ b/packages/server/src/core/plugin-platform/__tests__/host.test.ts
@@ -38,6 +38,7 @@ async function createPluginPackage(root: string, options: {
     displayName?: string;
     description?: string;
     category?: string;
+    topology?: Record<string, unknown>;
   };
   body?: string;
 }): Promise<void> {
@@ -780,6 +781,10 @@ export default {
       displayName: 'Bazaar',
       description: 'Trading venue module.',
       category: 'market',
+      topology: {
+        declaration: 'local',
+        mode: 'local',
+      },
     });
 
     const hooks = new HookRegistry();
@@ -797,6 +802,331 @@ export default {
     });
 
     await host.stopAll();
+  });
+
+  it('exposes local venue topology metadata in the lock and runtime diagnostics', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-local-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'local-topology');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.local',
+      packageName: '@acme/plugin-local',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.local',
+        namespace: 'acme.local',
+        topology: { mode: 'local' },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.local': {
+          pluginId: 'acme.local',
+          packageName: '@acme/plugin-local',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    const lock = await readCityLock(lockPath);
+    expect(lock.plugins['acme.local']?.venue?.topology).toEqual({
+      declaration: 'local',
+      mode: 'local',
+    });
+
+    const hooks = new HookRegistry();
+    const services = new ServiceRegistry();
+    const db = createDb(':memory:');
+    await host.startAll({ db, hooks, services });
+
+    expect(host.listPlugins().find((item) => item.name === 'acme.local')?.venue?.topology).toEqual({
+      declaration: 'local',
+      mode: 'local',
+    });
+    expect(host.getPluginDiagnostics().find((item) => item.pluginId === 'acme.local')?.venue?.topology).toEqual({
+      declaration: 'local',
+      mode: 'local',
+    });
+
+    await host.stopAll();
+  });
+
+  it('lets city config select domain mode for a domain-optional venue topology declaration', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'domain-topology');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.domain',
+      packageName: '@acme/plugin-domain',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.domain',
+        namespace: 'acme.domain',
+        topology: {
+          mode: 'domain_optional',
+          domain: {
+            endpoint: 'https://domain.example/acme',
+            document: 'https://domain.example/.well-known/uruc-domain.json',
+          },
+        },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.domain': {
+          pluginId: 'acme.domain',
+          packageName: '@acme/plugin-domain',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+          topology: { mode: 'domain' },
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    const lock = await readCityLock(lockPath);
+    expect(lock.plugins['acme.domain']?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        endpoint: 'https://domain.example/acme',
+        document: 'https://domain.example/.well-known/uruc-domain.json',
+      },
+    });
+
+    const hooks = new HookRegistry();
+    const services = new ServiceRegistry();
+    const db = createDb(':memory:');
+    await host.startAll({ db, hooks, services });
+
+    expect(host.listPlugins().find((item) => item.name === 'acme.domain')?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        endpoint: 'https://domain.example/acme',
+        document: 'https://domain.example/.well-known/uruc-domain.json',
+      },
+    });
+    expect(host.getPluginDiagnostics().find((item) => item.pluginId === 'acme.domain')?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        endpoint: 'https://domain.example/acme',
+        document: 'https://domain.example/.well-known/uruc-domain.json',
+      },
+    });
+
+    await host.stopAll();
+  });
+
+  it('keeps a domain-optional venue local when city config selects local mode', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-local-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'domain-local-topology');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.domain-local',
+      packageName: '@acme/plugin-domain-local',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.domain-local',
+        namespace: 'acme.domain-local',
+        topology: {
+          mode: 'domain_optional',
+          domain: { endpoint: 'http://127.0.0.1:9/no-network-call' },
+        },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.domain-local': {
+          pluginId: 'acme.domain-local',
+          packageName: '@acme/plugin-domain-local',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+          topology: { mode: 'local' },
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    const lock = await readCityLock(lockPath);
+    expect(lock.plugins['acme.domain-local']?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'local',
+    });
+
+    const hooks = new HookRegistry();
+    const services = new ServiceRegistry();
+    const db = createDb(':memory:');
+    await host.startAll({ db, hooks, services });
+    expect(host.listPlugins().find((item) => item.name === 'acme.domain-local')?.state).toBe('active');
+
+    await host.stopAll();
+  });
+
+  it('fails with a stable diagnostic when domain-required topology has no city config', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-required-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'required-topology');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.required',
+      packageName: '@acme/plugin-required',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.required',
+        namespace: 'acme.required',
+        topology: {
+          mode: 'domain_required',
+          domain: { endpoint: 'https://domain.example/acme-required' },
+        },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.required': {
+          pluginId: 'acme.required',
+          packageName: '@acme/plugin-required',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    const lock = await readCityLock(lockPath);
+    expect(lock.plugins['acme.required']).toBeUndefined();
+    expect(host.getPluginDiagnostics().find((item) => item.pluginId === 'acme.required')).toMatchObject({
+      state: 'failed',
+      lastError: 'Plugin acme.required requires domain topology config',
+    });
+  });
+
+  it('fails with a stable diagnostic when city config selects domain for a local-only venue', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-unsupported-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'unsupported-topology');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.unsupported',
+      packageName: '@acme/plugin-unsupported',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.unsupported',
+        namespace: 'acme.unsupported',
+        topology: { mode: 'local' },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.unsupported': {
+          pluginId: 'acme.unsupported',
+          packageName: '@acme/plugin-unsupported',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+          topology: {
+            mode: 'domain',
+            domain: { endpoint: 'https://domain.example/acme-unsupported' },
+          },
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    expect(host.getPluginDiagnostics().find((item) => item.pluginId === 'acme.unsupported')).toMatchObject({
+      state: 'failed',
+      lastError: 'Plugin acme.unsupported does not support domain topology',
+    });
   });
 
   it('keeps resolving healthy plugins when one configured plugin cannot be locked', async () => {

--- a/packages/server/src/core/plugin-platform/host.ts
+++ b/packages/server/src/core/plugin-platform/host.ts
@@ -677,7 +677,7 @@ export class PluginPlatformHost implements PluginPlatformHealthProvider {
           packageName: resolved.expectedPackageName,
           version: resolved.expectedVersion,
           publisher: runtimeManifest.urucPlugin.publisher,
-          ...(runtimeManifest.urucPlugin.venue ? { venue: runtimeManifest.urucPlugin.venue } : {}),
+          venue: resolved.venue,
           revision,
           sourcePath: resolved.sourcePath,
           packageRoot,

--- a/packages/server/src/core/plugin-platform/inspection.ts
+++ b/packages/server/src/core/plugin-platform/inspection.ts
@@ -89,10 +89,7 @@ function resolveVenueTopology(
     throw new Error(`Plugin ${pluginId} requires domain topology config`);
   }
 
-  const domain = {
-    ...(declared.domain ?? {}),
-    ...(pluginConfig.topology?.domain ?? {}),
-  };
+  const domain = declared.domain ?? {};
   if (requestedMode === 'domain' && !domain.endpoint) {
     throw new Error(`Plugin ${pluginId} domain topology requires endpoint metadata`);
   }

--- a/packages/server/src/core/plugin-platform/inspection.ts
+++ b/packages/server/src/core/plugin-platform/inspection.ts
@@ -10,6 +10,8 @@ import type {
   PluginPackageManifest,
   PluginRuntimeState,
   ResolvedSourcePluginRelease,
+  VenueModuleManifest,
+  VenueTopologyMetadata,
 } from './types.js';
 
 export type PluginCheckLevel = 'ok' | 'warn' | 'fail';
@@ -23,6 +25,7 @@ export interface ResolvedConfiguredPlugin {
   sourcedRelease: ResolvedSourcePluginRelease | null;
   expectedPackageName: string;
   expectedVersion: string;
+  venue: VenueModuleManifest;
   permissionsRequested: string[];
   permissionsGranted: string[];
 }
@@ -63,6 +66,55 @@ export function aggregatePluginCheckLevel(levels: PluginCheckLevel[]): PluginChe
   if (levels.includes('fail')) return 'fail';
   if (levels.includes('warn')) return 'warn';
   return 'ok';
+}
+
+function resolveVenueTopology(
+  pluginId: string,
+  venue: VenueModuleManifest,
+  pluginConfig: CityPluginSpec,
+): VenueTopologyMetadata {
+  const declared = venue.topology ?? { declaration: 'local' as const, mode: 'local' as const };
+  const requestedMode = pluginConfig.topology?.mode ?? (declared.declaration === 'domain_required' ? undefined : 'local');
+
+  if (!requestedMode) {
+    throw new Error(`Plugin ${pluginId} requires domain topology config`);
+  }
+  if (requestedMode !== 'local' && requestedMode !== 'domain') {
+    throw new Error(`Plugin ${pluginId} has unsupported topology mode "${String(requestedMode)}"`);
+  }
+  if (declared.declaration === 'local' && requestedMode !== 'local') {
+    throw new Error(`Plugin ${pluginId} does not support domain topology`);
+  }
+  if (declared.declaration === 'domain_required' && requestedMode !== 'domain') {
+    throw new Error(`Plugin ${pluginId} requires domain topology config`);
+  }
+
+  const domain = {
+    ...(declared.domain ?? {}),
+    ...(pluginConfig.topology?.domain ?? {}),
+  };
+  if (requestedMode === 'domain' && !domain.endpoint) {
+    throw new Error(`Plugin ${pluginId} domain topology requires endpoint metadata`);
+  }
+
+  return {
+    declaration: declared.declaration,
+    mode: requestedMode,
+    ...(requestedMode === 'domain'
+      ? { domain: { ...domain } }
+      : {}),
+  };
+}
+
+function resolveVenueMetadata(
+  pluginId: string,
+  venue: VenueModuleManifest,
+  pluginConfig: CityPluginSpec,
+): VenueModuleManifest {
+  return {
+    ...venue,
+    topology: resolveVenueTopology(pluginId, venue, pluginConfig),
+  };
 }
 
 export async function resolveConfiguredPlugin(options: {
@@ -128,6 +180,7 @@ export async function resolveConfiguredPlugin(options: {
     sourcedRelease,
     expectedPackageName,
     expectedVersion,
+    venue: resolveVenueMetadata(options.pluginId, urucPlugin.venue!, options.pluginConfig),
     permissionsRequested,
     permissionsGranted,
   };

--- a/packages/server/src/core/plugin-platform/manifest.ts
+++ b/packages/server/src/core/plugin-platform/manifest.ts
@@ -7,6 +7,8 @@ import type {
   PluginFrontendBuildManifest,
   PluginPackageManifest,
   VenueModuleManifest,
+  VenueTopologyDeclaration,
+  VenueTopologyMetadata,
 } from './types.js';
 
 export type PluginPackageContractMode = 'source' | 'distribution';
@@ -34,6 +36,38 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined;
 }
 
+function normalizeTopology(raw: unknown): VenueTopologyMetadata | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Invalid urucPlugin.venue.topology');
+  }
+
+  const value = raw as Record<string, unknown>;
+  if (value.mode !== 'local' && value.mode !== 'domain_optional' && value.mode !== 'domain_required') {
+    throw new Error('Invalid urucPlugin.venue.topology.mode');
+  }
+
+  const domainValue = value.domain;
+  if (domainValue !== undefined && (!domainValue || typeof domainValue !== 'object')) {
+    throw new Error('Invalid urucPlugin.venue.topology.domain');
+  }
+  const domain = (domainValue ?? {}) as Record<string, unknown>;
+  const endpoint = optionalString(domain.endpoint);
+  const document = optionalString(domain.document);
+  const declaration = value.mode as VenueTopologyDeclaration;
+  const metadata: VenueTopologyMetadata = {
+    declaration,
+    mode: declaration === 'domain_required' ? 'domain' : 'local',
+  };
+  if (endpoint || document) {
+    metadata.domain = {
+      ...(endpoint ? { endpoint } : {}),
+      ...(document ? { document } : {}),
+    };
+  }
+  return metadata;
+}
+
 function normalizeVenueMetadata(
   raw: unknown,
   defaults: { pluginId: string; displayName: string; description?: string },
@@ -50,9 +84,11 @@ function normalizeVenueMetadata(
   const displayName = optionalString(value.displayName) ?? defaults.displayName;
   const description = optionalString(value.description) ?? defaults.description;
   const category = optionalString(value.category);
+  const topology = normalizeTopology(value.topology);
   if (displayName) metadata.displayName = displayName;
   if (description) metadata.description = description;
   if (category) metadata.category = category;
+  if (topology) metadata.topology = topology;
   return metadata;
 }
 

--- a/packages/server/src/core/plugin-platform/types.ts
+++ b/packages/server/src/core/plugin-platform/types.ts
@@ -57,10 +57,6 @@ export interface CityPluginSpec {
   devOverridePath?: string;
   topology?: {
     mode: VenueRuntimeTopologyMode;
-    domain?: {
-      endpoint?: string;
-      document?: string;
-    };
   };
   config?: Record<string, unknown>;
 }

--- a/packages/server/src/core/plugin-platform/types.ts
+++ b/packages/server/src/core/plugin-platform/types.ts
@@ -55,6 +55,13 @@ export interface CityPluginSpec {
   source?: string;
   permissionsGranted?: string[];
   devOverridePath?: string;
+  topology?: {
+    mode: VenueRuntimeTopologyMode;
+    domain?: {
+      endpoint?: string;
+      document?: string;
+    };
+  };
   config?: Record<string, unknown>;
 }
 
@@ -94,12 +101,25 @@ export interface PluginFrontendBuildManifest {
 
 export interface LockedPluginFrontendSpec extends PluginFrontendBuildManifest {}
 
+export type VenueTopologyDeclaration = 'local' | 'domain_optional' | 'domain_required';
+export type VenueRuntimeTopologyMode = 'local' | 'domain';
+
+export interface VenueTopologyMetadata {
+  declaration: VenueTopologyDeclaration;
+  mode: VenueRuntimeTopologyMode;
+  domain?: {
+    endpoint?: string;
+    document?: string;
+  };
+}
+
 export interface VenueModuleManifest {
   moduleId: string;
   namespace: string;
   displayName?: string;
   description?: string;
   category?: string;
+  topology?: VenueTopologyMetadata;
 }
 
 export interface LockedPluginSpec {


### PR DESCRIPTION
Closes #9.

## Implementation
- Added Venue Module topology declaration metadata for local, domain_optional, and domain_required.
- Added city config runtime topology selection with stable diagnostics for unsupported or missing domain config.
- Exposed compact topology metadata through city lock, listPlugins discovery, and runtime diagnostics.
- Added SDK schema/types and bilingual docs for topology declaration and city config selection.

## Checks
- npm run test --workspace=packages/server -- src/core/plugin-platform/__tests__/host.test.ts src/core/plugin-platform/__tests__/inspection.test.ts
- npm run docs:check
- npm run build --workspace=packages/server
- git diff --check

## Not in scope
- Domain handshake / Domain Document fetch (#10).
- Signed city-to-domain envelope dispatch (#11).
- Federation (#12).
- Venue business synchronization or plugin package mechanic changes.

## Dependency note
Landing this unblocks #10, which then gates #11 and #12.