### PR TITLE
feat: implement domain document attachment handshake

### DIFF
--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -303,7 +303,7 @@ Current city config contents include:
 - `pluginStoreDir`
 - `sources`
 - configured venue package specs
-- optional per-venue topology selection (`local` or `domain`)
+- optional per-venue topology selection (`local` or `domain`) and selected domain endpoint/document metadata
 
 Current city lock contents include resolved venue package runtime data such as:
 
@@ -334,7 +334,9 @@ Current city lock contents include resolved venue package runtime data such as:
 
 Failed venue modules are retained in diagnostics even when they do not become active.
 
-Topology support is declaration-only in this slice. Local modules stay local by default. Domain-capable modules can expose endpoint/document hints and city config can select domain runtime mode, but the host does not perform Domain Document fetch, attachment handshake, signed envelope dispatch, federation, or venue business synchronization.
+Local modules stay local by default. Domain-capable modules can expose endpoint/document hints and city config can select domain runtime mode plus the chosen Domain Service endpoint/document. The domain attachment layer is connection-only: it verifies the Domain Document, sends an attachment request, and stores a compact attachment receipt in `domain_attachments`. It does not perform signed envelope dispatch, federation, or venue business synchronization.
+
+Domain attachment records are core-owned audit state. Each record stores status (`pending`, `attached`, `failed`, or `detached`), domain id, city id, plugin id, venue module id, venue namespace, protocol version, endpoint/document URLs, capabilities, receipt code, receipt JSON, and timestamps. Attachment failure returns stable compact receipt codes and must not make later request dispatch appear successful.
 
 ### Runtime context exposed to backend venue modules
 

--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -336,7 +336,9 @@ Failed venue modules are retained in diagnostics even when they do not become ac
 
 Local modules stay local by default. Domain-capable modules can expose endpoint/document hints and city config can select domain runtime mode plus the chosen Domain Service endpoint/document. The domain attachment layer is connection-only: it verifies the Domain Document, sends an attachment request, and stores a compact attachment receipt in `domain_attachments`. It does not perform signed envelope dispatch, federation, or venue business synchronization.
 
-Domain attachment records are core-owned audit state. Each record stores status (`pending`, `attached`, `failed`, or `detached`), domain id, city id, plugin id, venue module id, venue namespace, protocol version, endpoint/document URLs, capabilities, receipt code, receipt JSON, and timestamps. Attachment failure returns stable compact receipt codes and must not make later request dispatch appear successful.
+Domain attachment records are core-owned audit state. Each record stores status (`pending`, `attached`, `failed`, or `detached`), domain id, city id, plugin id, venue module id, venue namespace, protocol version, endpoint/document URLs, Domain Document hash, capabilities, receipt code, receipt JSON, and timestamps. Attachment failure returns stable compact receipt codes and must not make later request dispatch appear successful.
+
+Domain Document v0 uses schema id `uruc.domain.document@v0` and protocol version `uruc-domain-v0`. The Ed25519 proof signs the sorted JSON document without the `proof` object and must declare the exact covered top-level fields (`capabilities`, `domainId`, `endpoints`, `hints`, `protocol`, `publicKeys`, `schema`, and `venue`). Fetch and receipt parsing require JSON content types, bounded response sizes, parseable JSON, and stable compact error codes.
 
 ### Runtime context exposed to backend venue modules
 

--- a/docs/core-architecture.zh-CN.md
+++ b/docs/core-architecture.zh-CN.md
@@ -336,7 +336,9 @@ Venue Module 包宿主当前使用两个文件：
 
 Local module 默认保持 local。Domain-capable module 可以暴露 endpoint/document hints，city config 可以选择 domain runtime mode 以及被选择的 Domain Service endpoint/document。domain attachment layer 只负责连接：校验 Domain Document，发送 attachment request，并把紧凑 attachment receipt 写入 `domain_attachments`。它不执行 signed envelope dispatch、federation 或 Venue 业务同步。
 
-Domain attachment record 是 City Core 拥有的 audit state。每条记录包含状态（`pending`、`attached`、`failed` 或 `detached`）、domain id、city id、plugin id、venue module id、venue namespace、protocol version、endpoint/document URLs、capabilities、receipt code、receipt JSON 和时间戳。Attachment 失败会返回稳定的紧凑 receipt code，且不能让后续 request dispatch 假装成功。
+Domain attachment record 是 City Core 拥有的 audit state。每条记录包含状态（`pending`、`attached`、`failed` 或 `detached`）、domain id、city id、plugin id、venue module id、venue namespace、protocol version、endpoint/document URLs、Domain Document hash、capabilities、receipt code、receipt JSON 和时间戳。Attachment 失败会返回稳定的紧凑 receipt code，且不能让后续 request dispatch 假装成功。
+
+Domain Document v0 使用 schema id `uruc.domain.document@v0` 和 protocol version `uruc-domain-v0`。Ed25519 proof 签名的是移除 `proof` 对象后的 sorted JSON document，并且必须声明精确的顶层 covered fields（`capabilities`、`domainId`、`endpoints`、`hints`、`protocol`、`publicKeys`、`schema` 和 `venue`）。Fetch 和 receipt 解析要求 JSON content type、有界 response size、可解析 JSON，以及稳定的紧凑错误码。
 
 ### 后端 Venue Module 可见的运行时上下文
 

--- a/docs/core-architecture.zh-CN.md
+++ b/docs/core-architecture.zh-CN.md
@@ -303,7 +303,7 @@ Venue Module 包宿主当前使用两个文件：
 - `pluginStoreDir`
 - `sources`
 - 已配置场馆包规格
-- 可选的 per-venue topology selection（`local` 或 `domain`）
+- 可选的 per-venue topology selection（`local` 或 `domain`）以及已选择 domain endpoint/document metadata
 
 当前 city lock 包含的已解析场馆包运行时信息包括：
 
@@ -334,7 +334,9 @@ Venue Module 包宿主当前使用两个文件：
 
 即使 Venue Module 没有进入 active 状态，失败信息仍会保留在 diagnostics 中。
 
-本 slice 的 topology 只是声明。Local module 默认保持 local。Domain-capable module 可以暴露 endpoint/document hints，city config 可以选择 domain runtime mode，但 host 不会执行 Domain Document 拉取、attachment handshake、signed envelope dispatch、federation 或 Venue 业务同步。
+Local module 默认保持 local。Domain-capable module 可以暴露 endpoint/document hints，city config 可以选择 domain runtime mode 以及被选择的 Domain Service endpoint/document。domain attachment layer 只负责连接：校验 Domain Document，发送 attachment request，并把紧凑 attachment receipt 写入 `domain_attachments`。它不执行 signed envelope dispatch、federation 或 Venue 业务同步。
+
+Domain attachment record 是 City Core 拥有的 audit state。每条记录包含状态（`pending`、`attached`、`failed` 或 `detached`）、domain id、city id、plugin id、venue module id、venue namespace、protocol version、endpoint/document URLs、capabilities、receipt code、receipt JSON 和时间戳。Attachment 失败会返回稳定的紧凑 receipt code，且不能让后续 request dispatch 假装成功。
 
 ### 后端 Venue Module 可见的运行时上下文
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -146,9 +146,11 @@ Venue metadata:
 | `venue.category` | Optional category such as `communication`, `game`, `market`, or `public space` |
 | `venue.topology.mode` | `local`, `domain_optional`, or `domain_required`; omitted metadata defaults to local |
 | `venue.topology.domain.endpoint` | Optional domain endpoint hint for domain-capable modules |
-| `venue.topology.domain.document` | Optional Domain Document URL hint; the handshake itself is not implemented in this slice |
+| `venue.topology.domain.document` | Optional Domain Document URL hint |
 
-City config may select runtime topology with `plugins[pluginId].topology.mode` as `local` or `domain`. `domain_optional` modules default to local unless city config selects domain. `domain_required` modules fail resolution until city config selects domain. This declaration does not perform a network call or domain handshake.
+City config may select runtime topology with `plugins[pluginId].topology.mode` as `local` or `domain`. `domain_optional` modules default to local unless city config selects domain. `domain_required` modules fail resolution until city config selects domain. For domain runtime mode, city config may also provide `plugins[pluginId].topology.domain.endpoint` and `plugins[pluginId].topology.domain.document` to point at the chosen Domain Service and Domain Document without changing package identity, module id, or namespace.
+
+Domain Document and attachment handshake support is limited to connection metadata. City Core fetches and validates the Domain Document, sends an attachment request, and records an auditable attachment receipt. It does not send signed request dispatch envelopes; that belongs to #11. It does not define federation; that belongs to #12. Venue business synchronization remains owned by venue/domain protocols, not City Core.
 
 Useful optional fields:
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -150,7 +150,7 @@ Venue metadata:
 
 City config may select runtime topology with `plugins[pluginId].topology.mode` as `local` or `domain`. `domain_optional` modules default to local unless city config selects domain. `domain_required` modules fail resolution until city config selects domain. For domain runtime mode, city config may also provide `plugins[pluginId].topology.domain.endpoint` and `plugins[pluginId].topology.domain.document` to point at the chosen Domain Service and Domain Document without changing package identity, module id, or namespace.
 
-Domain Document and attachment handshake support is limited to connection metadata. City Core fetches and validates the Domain Document, sends an attachment request, and records an auditable attachment receipt. It does not send signed request dispatch envelopes; that belongs to #11. It does not define federation; that belongs to #12. Venue business synchronization remains owned by venue/domain protocols, not City Core.
+Domain Document and attachment handshake support is limited to connection metadata. City Core fetches and validates the Domain Document, sends an attachment request, and records an auditable attachment receipt with the Domain Document hash. The v0 proof signs the sorted JSON document without the `proof` object and must declare the exact covered top-level fields. It does not send signed request dispatch envelopes; that belongs to #11. It does not define federation; that belongs to #12. Venue business synchronization remains owned by venue/domain protocols, not City Core.
 
 Useful optional fields:
 

--- a/docs/plugin-development.zh-CN.md
+++ b/docs/plugin-development.zh-CN.md
@@ -150,7 +150,7 @@ Venue metadata：
 
 City config 可以通过 `plugins[pluginId].topology.mode` 选择 `local` 或 `domain` runtime topology。`domain_optional` 默认 local，除非 city config 选择 domain。`domain_required` 在 city config 选择 domain 前会解析失败。对于 domain runtime mode，city config 也可以提供 `plugins[pluginId].topology.domain.endpoint` 和 `plugins[pluginId].topology.domain.document`，用于指向被选择的 Domain Service 和 Domain Document，但不会改变 package identity、module id 或 namespace。
 
-Domain Document 和 attachment handshake 支持仅限连接 metadata。City Core 会拉取并校验 Domain Document，发送 attachment request，并记录可审计 attachment receipt。它不会发送 signed request dispatch envelope；那属于 #11。它不会定义 federation；那属于 #12。Venue 业务同步仍由 venue/domain protocols 拥有，不属于 City Core。
+Domain Document 和 attachment handshake 支持仅限连接 metadata。City Core 会拉取并校验 Domain Document，发送 attachment request，并记录带有 Domain Document hash 的可审计 attachment receipt。v0 proof 签名的是移除 `proof` 对象后的 sorted JSON document，并且必须声明精确的顶层 covered fields。它不会发送 signed request dispatch envelope；那属于 #11。它不会定义 federation；那属于 #12。Venue 业务同步仍由 venue/domain protocols 拥有，不属于 City Core。
 
 常用可选字段：
 

--- a/docs/plugin-development.zh-CN.md
+++ b/docs/plugin-development.zh-CN.md
@@ -146,9 +146,11 @@ Venue metadata：
 | `venue.category` | 可选分类，例如 `communication`、`game`、`market` 或 `public space` |
 | `venue.topology.mode` | `local`、`domain_optional` 或 `domain_required`；未声明时默认 local |
 | `venue.topology.domain.endpoint` | domain-capable module 的可选 Domain endpoint hint |
-| `venue.topology.domain.document` | 可选 Domain Document URL hint；本 slice 不实现 handshake |
+| `venue.topology.domain.document` | 可选 Domain Document URL hint |
 
-City config 可以通过 `plugins[pluginId].topology.mode` 选择 `local` 或 `domain` runtime topology。`domain_optional` 默认 local，除非 city config 选择 domain。`domain_required` 在 city config 选择 domain 前会解析失败。该声明不会发起网络请求或 domain handshake。
+City config 可以通过 `plugins[pluginId].topology.mode` 选择 `local` 或 `domain` runtime topology。`domain_optional` 默认 local，除非 city config 选择 domain。`domain_required` 在 city config 选择 domain 前会解析失败。对于 domain runtime mode，city config 也可以提供 `plugins[pluginId].topology.domain.endpoint` 和 `plugins[pluginId].topology.domain.document`，用于指向被选择的 Domain Service 和 Domain Document，但不会改变 package identity、module id 或 namespace。
+
+Domain Document 和 attachment handshake 支持仅限连接 metadata。City Core 会拉取并校验 Domain Document，发送 attachment request，并记录可审计 attachment receipt。它不会发送 signed request dispatch envelope；那属于 #11。它不会定义 federation；那属于 #12。Venue 业务同步仍由 venue/domain protocols 拥有，不属于 City Core。
 
 常用可选字段：
 

--- a/packages/server/src/core/database/index.ts
+++ b/packages/server/src/core/database/index.ts
@@ -89,6 +89,7 @@ export function createDb(dbPath: string = getDbPath()) {
     protocol_version TEXT NOT NULL,
     endpoint TEXT NOT NULL,
     document_url TEXT NOT NULL,
+    document_hash TEXT NOT NULL,
     capabilities TEXT NOT NULL,
     receipt_code TEXT NOT NULL,
     receipt TEXT NOT NULL,

--- a/packages/server/src/core/database/index.ts
+++ b/packages/server/src/core/database/index.ts
@@ -78,6 +78,26 @@ export function createDb(dbPath: string = getDbPath()) {
     CHECK (resident_id <> accountable_principal_id)
   )`);
 
+  db.run(sql`CREATE TABLE IF NOT EXISTS domain_attachments (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    domain_id TEXT NOT NULL,
+    city_id TEXT NOT NULL,
+    plugin_id TEXT NOT NULL,
+    venue_module_id TEXT NOT NULL,
+    venue_namespace TEXT NOT NULL,
+    protocol_version TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    document_url TEXT NOT NULL,
+    capabilities TEXT NOT NULL,
+    receipt_code TEXT NOT NULL,
+    receipt TEXT NOT NULL,
+    issued_at INTEGER,
+    valid_until INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+
   db.run(sql`CREATE TABLE IF NOT EXISTS action_logs (
     id TEXT PRIMARY KEY, user_id TEXT NOT NULL, agent_id TEXT NOT NULL,
     location_id TEXT, action_type TEXT NOT NULL, payload TEXT,
@@ -89,6 +109,7 @@ export function createDb(dbPath: string = getDbPath()) {
   db.run(sql`CREATE UNIQUE INDEX IF NOT EXISTS agents_shadow_unique ON agents(user_id) WHERE is_shadow = 1`);
   db.run(sql`CREATE INDEX IF NOT EXISTS permission_credentials_resident_status ON permission_credentials(resident_id, status)`);
   db.run(sql`CREATE INDEX IF NOT EXISTS principal_backed_residents_principal ON principal_backed_residents(accountable_principal_id)`);
+  db.run(sql`CREATE INDEX IF NOT EXISTS domain_attachments_venue_status ON domain_attachments(plugin_id, venue_module_id, status)`);
 
   return db;
 }

--- a/packages/server/src/core/database/schema.ts
+++ b/packages/server/src/core/database/schema.ts
@@ -2,7 +2,7 @@
  * Core Database Schema — only tables owned by core modules.
  *
  * Plugin tables are defined in each plugin's own schema file.
- * Core tables: users, pending_registrations, oauth_accounts, agents, permission_credentials, principal_backed_residents, action_logs
+ * Core tables: users, pending_registrations, oauth_accounts, agents, permission_credentials, principal_backed_residents, domain_attachments, action_logs
  */
 
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
@@ -72,6 +72,28 @@ export const principalBackedResidents = sqliteTable('principal_backed_residents'
   residentId: text('resident_id').primaryKey().references(() => agents.id),
   accountablePrincipalId: text('accountable_principal_id').notNull().references(() => agents.id),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+});
+
+// === core/domain ===
+
+export const domainAttachments = sqliteTable('domain_attachments', {
+  id: text('id').primaryKey(),
+  status: text('status', { enum: ['pending', 'attached', 'failed', 'detached'] }).notNull(),
+  domainId: text('domain_id').notNull(),
+  cityId: text('city_id').notNull(),
+  pluginId: text('plugin_id').notNull(),
+  venueModuleId: text('venue_module_id').notNull(),
+  venueNamespace: text('venue_namespace').notNull(),
+  protocolVersion: text('protocol_version').notNull(),
+  endpoint: text('endpoint').notNull(),
+  documentUrl: text('document_url').notNull(),
+  capabilities: text('capabilities').notNull(),
+  receiptCode: text('receipt_code').notNull(),
+  receipt: text('receipt').notNull(),
+  issuedAt: integer('issued_at', { mode: 'timestamp' }),
+  validUntil: integer('valid_until', { mode: 'timestamp' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 });
 
 // === core/logger ===

--- a/packages/server/src/core/database/schema.ts
+++ b/packages/server/src/core/database/schema.ts
@@ -87,6 +87,7 @@ export const domainAttachments = sqliteTable('domain_attachments', {
   protocolVersion: text('protocol_version').notNull(),
   endpoint: text('endpoint').notNull(),
   documentUrl: text('document_url').notNull(),
+  documentHash: text('document_hash').notNull(),
   capabilities: text('capabilities').notNull(),
   receiptCode: text('receipt_code').notNull(),
   receipt: text('receipt').notNull(),

--- a/packages/server/src/core/domain/__tests__/domain-attachment.test.ts
+++ b/packages/server/src/core/domain/__tests__/domain-attachment.test.ts
@@ -40,6 +40,17 @@ function signedDocument(overrides: Record<string, unknown> = {}) {
       type: 'ed25519-signature-2026',
       verificationMethod: 'domain-key-1',
       createdAt: '2026-05-03T00:00:00.000Z',
+      canonicalization: 'uruc-domain-document-v0-sorted-json-without-proof',
+      covered: [
+        'capabilities',
+        'domainId',
+        'endpoints',
+        'hints',
+        'protocol',
+        'publicKeys',
+        'schema',
+        'venue',
+      ],
       signature: sign(null, canonicalDomainDocumentPayload(unsigned), privateKey).toString('base64'),
     },
   };
@@ -91,6 +102,28 @@ describe('Domain Document', () => {
       expectedVenueNamespace: 'acme.social',
     })).toThrow(expect.objectContaining({
       code: 'DOMAIN_DOCUMENT_ENDPOINT_INVALID',
+    }));
+  });
+
+  it('rejects documents with extra fields or ambiguous proof coverage', () => {
+    expect(() => parseDomainDocument(signedDocument({
+      dispatch: {
+        endpoint: 'https://domain.example/dispatch',
+      },
+    }), {
+      expectedVenueModuleId: 'acme.social',
+      expectedVenueNamespace: 'acme.social',
+    })).toThrow(expect.objectContaining({
+      code: 'DOMAIN_DOCUMENT_FIELD_INVALID',
+    }));
+
+    const document = signedDocument();
+    (document.proof.covered as string[]).pop();
+    expect(() => parseDomainDocument(document, {
+      expectedVenueModuleId: 'acme.social',
+      expectedVenueNamespace: 'acme.social',
+    })).toThrow(expect.objectContaining({
+      code: 'DOMAIN_DOCUMENT_PROOF_INVALID',
     }));
   });
 });
@@ -197,6 +230,7 @@ describe('Domain attachment handshake', () => {
         protocolVersion: 'uruc-domain-v0',
         receiptCode: 'ATTACHED',
       });
+      expect(rows[0]?.documentHash).toMatch(/^[a-f0-9]{64}$/);
       expect(rows[0]?.validUntil?.toISOString()).toBe('2026-06-03T00:00:00.000Z');
     } finally {
       await close(server);
@@ -348,6 +382,47 @@ describe('Domain attachment handshake', () => {
     }
   });
 
+  it('returns a stable compact receipt when Domain Document content-type is not JSON', async () => {
+    const db = createDb(':memory:');
+    const server = createServer((_req, res) => {
+      res.setHeader('content-type', 'text/plain');
+      res.end(JSON.stringify(signedDocument()));
+    });
+    const baseUrl = await listen(server);
+
+    try {
+      const service = new DomainAttachmentService(db);
+      const result = await service.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: {
+              document: `${baseUrl}/.well-known/uruc-domain.json`,
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        status: 'failed',
+        receipt: {
+          ok: false,
+          code: 'DOMAIN_DOCUMENT_CONTENT_TYPE_INVALID',
+          cityId: 'city.alpha',
+          venueModuleId: 'acme.social',
+        },
+      });
+      expect(await db.select().from(schema.domainAttachments)).toHaveLength(0);
+    } finally {
+      await close(server);
+    }
+  });
+
   it('returns a stable compact receipt when Domain Document fetch times out', async () => {
     const db = createDb(':memory:');
     const service = new DomainAttachmentService(db, {
@@ -385,5 +460,143 @@ describe('Domain attachment handshake', () => {
       },
     });
     expect(await db.select().from(schema.domainAttachments)).toHaveLength(0);
+  });
+
+  it('marks accepted but expired attachment receipts as failed', async () => {
+    const db = createDb(':memory:');
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(signedDocument({
+          endpoints: {
+            attachment: `${baseUrl}/uruc/attach`,
+          },
+        })));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'accepted',
+          code: 'ATTACHED',
+          receiptId: 'receipt-expired',
+          validUntil: '2026-05-02T00:00:00.000Z',
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const service = new DomainAttachmentService(db, {
+        now: () => new Date('2026-05-03T00:00:00.000Z'),
+      });
+      const result = await service.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: {
+              endpoint: baseUrl,
+            },
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'failed',
+        receipt: {
+          ok: false,
+          code: 'DOMAIN_ATTACHMENT_EXPIRED',
+          cityId: 'city.alpha',
+          venueModuleId: 'acme.social',
+          domainId: 'domain.acme.social',
+        },
+      });
+      const rows = await db.select().from(schema.domainAttachments);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        status: 'failed',
+        receiptCode: 'DOMAIN_ATTACHMENT_EXPIRED',
+      });
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('keeps the attachment failed when the receipt content-type is not JSON', async () => {
+    const db = createDb(':memory:');
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(signedDocument({
+          endpoints: {
+            attachment: `${baseUrl}/uruc/attach`,
+          },
+        })));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.setHeader('content-type', 'text/plain');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'accepted',
+          code: 'ATTACHED',
+          receiptId: 'receipt-plain',
+          validUntil: '2026-06-03T00:00:00.000Z',
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const service = new DomainAttachmentService(db);
+      const result = await service.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: {
+              endpoint: baseUrl,
+            },
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'failed',
+        receipt: {
+          ok: false,
+          code: 'DOMAIN_ATTACHMENT_RECEIPT_CONTENT_TYPE_INVALID',
+          cityId: 'city.alpha',
+          venueModuleId: 'acme.social',
+          domainId: 'domain.acme.social',
+        },
+      });
+      const rows = await db.select().from(schema.domainAttachments);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        status: 'failed',
+        receiptCode: 'DOMAIN_ATTACHMENT_RECEIPT_CONTENT_TYPE_INVALID',
+      });
+    } finally {
+      await close(server);
+    }
   });
 });

--- a/packages/server/src/core/domain/__tests__/domain-attachment.test.ts
+++ b/packages/server/src/core/domain/__tests__/domain-attachment.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from 'vitest';
+import { generateKeyPairSync, sign } from 'crypto';
+import { createServer, type Server } from 'http';
+import { AddressInfo } from 'net';
+
+import { createDb, schema } from '../../database/index.js';
+import { canonicalDomainDocumentPayload, parseDomainDocument } from '../document.js';
+import { DomainAttachmentService } from '../service.js';
+
+function signedDocument(overrides: Record<string, unknown> = {}) {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const publicKeyPem = publicKey.export({ format: 'pem', type: 'spki' }).toString();
+  const unsigned = {
+    schema: 'uruc.domain.document@v0',
+    domainId: 'domain.acme.social',
+    venue: {
+      moduleId: 'acme.social',
+      namespace: 'acme.social',
+    },
+    protocol: {
+      version: 'uruc-domain-v0',
+    },
+    publicKeys: [{
+      id: 'domain-key-1',
+      type: 'ed25519-pem',
+      publicKeyPem,
+    }],
+    endpoints: {
+      attachment: 'https://domain.example/uruc/attach',
+    },
+    capabilities: ['social.thread.read'],
+    hints: {
+      retention: '30d',
+    },
+    ...overrides,
+  };
+  return {
+    ...unsigned,
+    proof: {
+      type: 'ed25519-signature-2026',
+      verificationMethod: 'domain-key-1',
+      createdAt: '2026-05-03T00:00:00.000Z',
+      signature: sign(null, canonicalDomainDocumentPayload(unsigned), privateKey).toString('base64'),
+    },
+  };
+}
+
+describe('Domain Document', () => {
+  it('parses and verifies a signed domain document for one venue module', () => {
+    const document = parseDomainDocument(signedDocument(), {
+      expectedVenueModuleId: 'acme.social',
+      expectedVenueNamespace: 'acme.social',
+      expectedProtocolVersion: 'uruc-domain-v0',
+    });
+
+    expect(document).toMatchObject({
+      domainId: 'domain.acme.social',
+      venue: {
+        moduleId: 'acme.social',
+        namespace: 'acme.social',
+      },
+      protocol: {
+        version: 'uruc-domain-v0',
+      },
+      endpoints: {
+        attachment: 'https://domain.example/uruc/attach',
+      },
+      capabilities: ['social.thread.read'],
+      hints: {
+        retention: '30d',
+      },
+    });
+  });
+
+  it('returns stable validation codes for invalid document fields', () => {
+    expect(() => parseDomainDocument(signedDocument({
+      domainId: '',
+    }), {
+      expectedVenueModuleId: 'acme.social',
+      expectedVenueNamespace: 'acme.social',
+    })).toThrow(expect.objectContaining({
+      code: 'DOMAIN_DOCUMENT_DOMAIN_INVALID',
+    }));
+
+    expect(() => parseDomainDocument(signedDocument({
+      endpoints: {
+        attachment: 'not-a-url',
+      },
+    }), {
+      expectedVenueModuleId: 'acme.social',
+      expectedVenueNamespace: 'acme.social',
+    })).toThrow(expect.objectContaining({
+      code: 'DOMAIN_DOCUMENT_ENDPOINT_INVALID',
+    }));
+  });
+});
+
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('Domain attachment handshake', () => {
+  it('fetches a Domain Document, performs attachment, and stores an accepted attachment record', async () => {
+    const db = createDb(':memory:');
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(signedDocument({
+          endpoints: {
+            attachment: `${baseUrl}/uruc/attach`,
+          },
+        })));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          expect(JSON.parse(body)).toMatchObject({
+            schema: 'uruc.domain.attachment.request@v0',
+            cityId: 'city.alpha',
+            domainId: 'domain.acme.social',
+            pluginId: 'acme.social',
+            venue: {
+              moduleId: 'acme.social',
+              namespace: 'acme.social',
+            },
+            protocolVersion: 'uruc-domain-v0',
+          });
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({
+            schema: 'uruc.domain.attachment.receipt@v0',
+            status: 'accepted',
+            code: 'ATTACHED',
+            receiptId: 'receipt-1',
+            validUntil: '2026-06-03T00:00:00.000Z',
+            capabilities: ['social.thread.read'],
+          }));
+        });
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const service = new DomainAttachmentService(db);
+      const result = await service.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: {
+              endpoint: baseUrl,
+            },
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'attached',
+        receipt: {
+          ok: true,
+          code: 'ATTACHED',
+          domainId: 'domain.acme.social',
+          cityId: 'city.alpha',
+          venueModuleId: 'acme.social',
+        },
+      });
+
+      const rows = await db.select().from(schema.domainAttachments);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        status: 'attached',
+        domainId: 'domain.acme.social',
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venueModuleId: 'acme.social',
+        venueNamespace: 'acme.social',
+        protocolVersion: 'uruc-domain-v0',
+        receiptCode: 'ATTACHED',
+      });
+      expect(rows[0]?.validUntil?.toISOString()).toBe('2026-06-03T00:00:00.000Z');
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('stores a failed attachment record and compact receipt when the domain rejects attachment', async () => {
+    const db = createDb(':memory:');
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(signedDocument({
+          endpoints: {
+            attachment: `${baseUrl}/uruc/attach`,
+          },
+        })));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.statusCode = 409;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'rejected',
+          code: 'CITY_NOT_ALLOWED',
+          receiptId: 'reject-1',
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const service = new DomainAttachmentService(db);
+      const result = await service.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_optional',
+            mode: 'domain',
+            domain: {
+              document: `${baseUrl}/.well-known/uruc-domain.json`,
+            },
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'failed',
+        receipt: {
+          ok: false,
+          code: 'CITY_NOT_ALLOWED',
+          domainId: 'domain.acme.social',
+          cityId: 'city.alpha',
+          venueModuleId: 'acme.social',
+        },
+      });
+      const rows = await db.select().from(schema.domainAttachments);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        status: 'failed',
+        receiptCode: 'CITY_NOT_ALLOWED',
+      });
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('does not fetch or create attachment records for local topology', async () => {
+    const db = createDb(':memory:');
+    const service = new DomainAttachmentService(db, {
+      fetch: async () => {
+        throw new Error('local topology should not fetch');
+      },
+    });
+
+    const result = await service.attachVenueDomain({
+      cityId: 'city.alpha',
+      pluginId: 'acme.local',
+      venue: {
+        moduleId: 'acme.local',
+        namespace: 'acme.local',
+        topology: {
+          declaration: 'local',
+          mode: 'local',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'skipped',
+      receipt: {
+        ok: true,
+        code: 'LOCAL_TOPOLOGY',
+        cityId: 'city.alpha',
+        venueModuleId: 'acme.local',
+      },
+    });
+    expect(await db.select().from(schema.domainAttachments)).toHaveLength(0);
+  });
+
+  it('returns a stable compact receipt when Domain Document fetch exceeds the size limit', async () => {
+    const db = createDb(':memory:');
+    const server = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({
+        schema: 'uruc.domain.document@v0',
+        padding: 'x'.repeat(256),
+      }));
+    });
+    const baseUrl = await listen(server);
+
+    try {
+      const service = new DomainAttachmentService(db, { maxDocumentBytes: 64 });
+      const result = await service.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: {
+              document: `${baseUrl}/.well-known/uruc-domain.json`,
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        status: 'failed',
+        receipt: {
+          ok: false,
+          code: 'DOMAIN_RESPONSE_TOO_LARGE',
+          cityId: 'city.alpha',
+          venueModuleId: 'acme.social',
+        },
+      });
+      expect(await db.select().from(schema.domainAttachments)).toHaveLength(0);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('returns a stable compact receipt when Domain Document fetch times out', async () => {
+    const db = createDb(':memory:');
+    const service = new DomainAttachmentService(db, {
+      timeoutMs: 1,
+      fetch: async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+        });
+      }),
+    });
+
+    const result = await service.attachVenueDomain({
+      cityId: 'city.alpha',
+      pluginId: 'acme.social',
+      venue: {
+        moduleId: 'acme.social',
+        namespace: 'acme.social',
+        topology: {
+          declaration: 'domain_required',
+          mode: 'domain',
+          domain: {
+            document: 'https://domain.example/.well-known/uruc-domain.json',
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      receipt: {
+        ok: false,
+        code: 'DOMAIN_REQUEST_TIMEOUT',
+        cityId: 'city.alpha',
+        venueModuleId: 'acme.social',
+      },
+    });
+    expect(await db.select().from(schema.domainAttachments)).toHaveLength(0);
+  });
+});

--- a/packages/server/src/core/domain/document.ts
+++ b/packages/server/src/core/domain/document.ts
@@ -2,6 +2,17 @@ import { createPublicKey, verify } from 'crypto';
 
 export const DOMAIN_DOCUMENT_SCHEMA = 'uruc.domain.document@v0';
 export const DOMAIN_PROTOCOL_VERSION = 'uruc-domain-v0';
+export const DOMAIN_DOCUMENT_CANONICALIZATION = 'uruc-domain-document-v0-sorted-json-without-proof';
+export const DOMAIN_DOCUMENT_SIGNED_FIELDS = [
+  'capabilities',
+  'domainId',
+  'endpoints',
+  'hints',
+  'protocol',
+  'publicKeys',
+  'schema',
+  'venue',
+] as const;
 
 export interface DomainDocument {
   schema: typeof DOMAIN_DOCUMENT_SCHEMA;
@@ -27,6 +38,8 @@ export interface DomainDocument {
     type: 'ed25519-signature-2026';
     verificationMethod: string;
     createdAt: string;
+    canonicalization: typeof DOMAIN_DOCUMENT_CANONICALIZATION;
+    covered: Array<(typeof DOMAIN_DOCUMENT_SIGNED_FIELDS)[number]>;
     signature: string;
   };
 }
@@ -77,6 +90,27 @@ function requireStringArray(value: unknown, code: string, label: string): string
   return [...value];
 }
 
+function requireExactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  code: string,
+  label: string,
+): void {
+  const extra = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (extra.length > 0) {
+    throw new DomainDocumentError(code, `Invalid Domain Document ${label}`);
+  }
+}
+
+function requireIsoTimestamp(value: unknown, code: string, label: string): string {
+  const text = requireString(value, code, label);
+  const time = Date.parse(text);
+  if (Number.isNaN(time) || new Date(time).toISOString() !== text) {
+    throw new DomainDocumentError(code, `Invalid Domain Document ${label}`);
+  }
+  return text;
+}
+
 function stableValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stableValue);
   if (!isRecord(value)) return value;
@@ -96,6 +130,7 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
   if (!isRecord(raw)) {
     throw new DomainDocumentError('DOMAIN_DOCUMENT_INVALID', 'Invalid Domain Document');
   }
+  requireExactKeys(raw, [...DOMAIN_DOCUMENT_SIGNED_FIELDS, 'proof'], 'DOMAIN_DOCUMENT_FIELD_INVALID', 'top-level fields');
   const venue = raw.venue;
   const protocol = raw.protocol;
   const endpoints = raw.endpoints;
@@ -104,6 +139,10 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
   if (!isRecord(protocol)) throw new DomainDocumentError('DOMAIN_DOCUMENT_PROTOCOL_INVALID', 'Invalid Domain Document protocol');
   if (!isRecord(endpoints)) throw new DomainDocumentError('DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'Invalid Domain Document endpoints');
   if (!isRecord(proof)) throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof');
+  requireExactKeys(venue, ['moduleId', 'namespace'], 'DOMAIN_DOCUMENT_VENUE_INVALID', 'venue fields');
+  requireExactKeys(protocol, ['version'], 'DOMAIN_DOCUMENT_PROTOCOL_INVALID', 'protocol fields');
+  requireExactKeys(endpoints, ['attachment'], 'DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'endpoint fields');
+  requireExactKeys(proof, ['type', 'verificationMethod', 'createdAt', 'canonicalization', 'covered', 'signature'], 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof fields');
 
   const publicKeysValue = raw.publicKeys;
   if (!Array.isArray(publicKeysValue) || publicKeysValue.length === 0) {
@@ -111,6 +150,7 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
   }
   const publicKeys = publicKeysValue.map((key) => {
     if (!isRecord(key)) throw new DomainDocumentError('DOMAIN_DOCUMENT_KEYS_INVALID', 'Invalid Domain Document publicKeys');
+    requireExactKeys(key, ['id', 'type', 'publicKeyPem'], 'DOMAIN_DOCUMENT_KEYS_INVALID', 'publicKeys fields');
     const type = requireString(key.type, 'DOMAIN_DOCUMENT_KEYS_INVALID', 'publicKeys.type');
     if (type !== 'ed25519-pem') {
       throw new DomainDocumentError('DOMAIN_DOCUMENT_KEYS_INVALID', 'Invalid Domain Document publicKeys.type');
@@ -125,6 +165,14 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
   const proofType = requireString(proof.type, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.type');
   if (proofType !== 'ed25519-signature-2026') {
     throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof.type');
+  }
+  const canonicalization = requireString(proof.canonicalization, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.canonicalization');
+  if (canonicalization !== DOMAIN_DOCUMENT_CANONICALIZATION) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof.canonicalization');
+  }
+  const covered = requireStringArray(proof.covered, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.covered');
+  if (JSON.stringify(covered) !== JSON.stringify(DOMAIN_DOCUMENT_SIGNED_FIELDS)) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof.covered');
   }
 
   const hints = raw.hints;
@@ -151,7 +199,9 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
     proof: {
       type: proofType,
       verificationMethod: requireString(proof.verificationMethod, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.verificationMethod'),
-      createdAt: requireString(proof.createdAt, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.createdAt'),
+      createdAt: requireIsoTimestamp(proof.createdAt, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.createdAt'),
+      canonicalization: DOMAIN_DOCUMENT_CANONICALIZATION,
+      covered: [...DOMAIN_DOCUMENT_SIGNED_FIELDS],
       signature: requireString(proof.signature, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.signature'),
     },
   };
@@ -176,12 +226,21 @@ export function parseDomainDocument(raw: unknown, expectations: DomainDocumentEx
   if (!verificationKey) {
     throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Domain Document proof key not found');
   }
-  const valid = verify(
-    null,
-    canonicalDomainDocumentPayload(document as unknown as Record<string, unknown>),
-    createPublicKey(verificationKey.publicKeyPem),
-    Buffer.from(document.proof.signature, 'base64'),
-  );
+  let valid = false;
+  try {
+    const signature = Buffer.from(document.proof.signature, 'base64');
+    if (signature.length === 0) {
+      throw new Error('empty signature');
+    }
+    valid = verify(
+      null,
+      canonicalDomainDocumentPayload(document as unknown as Record<string, unknown>),
+      createPublicKey(verificationKey.publicKeyPem),
+      signature,
+    );
+  } catch {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Domain Document proof cannot be verified');
+  }
   if (!valid) {
     throw new DomainDocumentError('DOMAIN_DOCUMENT_SIGNATURE_INVALID', 'Domain Document signature invalid');
   }

--- a/packages/server/src/core/domain/document.ts
+++ b/packages/server/src/core/domain/document.ts
@@ -1,0 +1,190 @@
+import { createPublicKey, verify } from 'crypto';
+
+export const DOMAIN_DOCUMENT_SCHEMA = 'uruc.domain.document@v0';
+export const DOMAIN_PROTOCOL_VERSION = 'uruc-domain-v0';
+
+export interface DomainDocument {
+  schema: typeof DOMAIN_DOCUMENT_SCHEMA;
+  domainId: string;
+  venue: {
+    moduleId: string;
+    namespace: string;
+  };
+  protocol: {
+    version: typeof DOMAIN_PROTOCOL_VERSION;
+  };
+  publicKeys: Array<{
+    id: string;
+    type: 'ed25519-pem';
+    publicKeyPem: string;
+  }>;
+  endpoints: {
+    attachment: string;
+  };
+  capabilities: string[];
+  hints?: Record<string, unknown>;
+  proof: {
+    type: 'ed25519-signature-2026';
+    verificationMethod: string;
+    createdAt: string;
+    signature: string;
+  };
+}
+
+export interface DomainDocumentExpectations {
+  expectedVenueModuleId: string;
+  expectedVenueNamespace: string;
+  expectedProtocolVersion?: string;
+}
+
+export class DomainDocumentError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireString(value: unknown, code: string, label: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new DomainDocumentError(code, `Invalid Domain Document ${label}`);
+  }
+  return value;
+}
+
+function requireUrl(value: unknown, code: string, label: string): string {
+  const text = requireString(value, code, label);
+  try {
+    const url = new URL(text);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('unsupported protocol');
+    }
+    return url.toString();
+  } catch {
+    throw new DomainDocumentError(code, `Invalid Domain Document ${label}`);
+  }
+}
+
+function requireStringArray(value: unknown, code: string, label: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.trim() === '')) {
+    throw new DomainDocumentError(code, `Invalid Domain Document ${label}`);
+  }
+  return [...value];
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, stableValue(value[key])]),
+  );
+}
+
+export function canonicalDomainDocumentPayload(document: Record<string, unknown>): Buffer {
+  const { proof: _proof, ...unsigned } = document;
+  return Buffer.from(JSON.stringify(stableValue(unsigned)), 'utf8');
+}
+
+function parseDomainDocumentShape(raw: unknown): DomainDocument {
+  if (!isRecord(raw)) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_INVALID', 'Invalid Domain Document');
+  }
+  const venue = raw.venue;
+  const protocol = raw.protocol;
+  const endpoints = raw.endpoints;
+  const proof = raw.proof;
+  if (!isRecord(venue)) throw new DomainDocumentError('DOMAIN_DOCUMENT_VENUE_INVALID', 'Invalid Domain Document venue');
+  if (!isRecord(protocol)) throw new DomainDocumentError('DOMAIN_DOCUMENT_PROTOCOL_INVALID', 'Invalid Domain Document protocol');
+  if (!isRecord(endpoints)) throw new DomainDocumentError('DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'Invalid Domain Document endpoints');
+  if (!isRecord(proof)) throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof');
+
+  const publicKeysValue = raw.publicKeys;
+  if (!Array.isArray(publicKeysValue) || publicKeysValue.length === 0) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_KEYS_INVALID', 'Invalid Domain Document publicKeys');
+  }
+  const publicKeys = publicKeysValue.map((key) => {
+    if (!isRecord(key)) throw new DomainDocumentError('DOMAIN_DOCUMENT_KEYS_INVALID', 'Invalid Domain Document publicKeys');
+    const type = requireString(key.type, 'DOMAIN_DOCUMENT_KEYS_INVALID', 'publicKeys.type');
+    if (type !== 'ed25519-pem') {
+      throw new DomainDocumentError('DOMAIN_DOCUMENT_KEYS_INVALID', 'Invalid Domain Document publicKeys.type');
+    }
+    return {
+      id: requireString(key.id, 'DOMAIN_DOCUMENT_KEYS_INVALID', 'publicKeys.id'),
+      type: 'ed25519-pem' as const,
+      publicKeyPem: requireString(key.publicKeyPem, 'DOMAIN_DOCUMENT_KEYS_INVALID', 'publicKeys.publicKeyPem'),
+    };
+  });
+
+  const proofType = requireString(proof.type, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.type');
+  if (proofType !== 'ed25519-signature-2026') {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof.type');
+  }
+
+  const hints = raw.hints;
+  if (hints !== undefined && !isRecord(hints)) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_HINTS_INVALID', 'Invalid Domain Document hints');
+  }
+
+  return {
+    schema: requireString(raw.schema, 'DOMAIN_DOCUMENT_SCHEMA_INVALID', 'schema') as typeof DOMAIN_DOCUMENT_SCHEMA,
+    domainId: requireString(raw.domainId, 'DOMAIN_DOCUMENT_DOMAIN_INVALID', 'domainId'),
+    venue: {
+      moduleId: requireString(venue.moduleId, 'DOMAIN_DOCUMENT_VENUE_INVALID', 'venue.moduleId'),
+      namespace: requireString(venue.namespace, 'DOMAIN_DOCUMENT_VENUE_INVALID', 'venue.namespace'),
+    },
+    protocol: {
+      version: requireString(protocol.version, 'DOMAIN_DOCUMENT_PROTOCOL_INVALID', 'protocol.version') as typeof DOMAIN_PROTOCOL_VERSION,
+    },
+    publicKeys,
+    endpoints: {
+      attachment: requireUrl(endpoints.attachment, 'DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'endpoints.attachment'),
+    },
+    capabilities: requireStringArray(raw.capabilities, 'DOMAIN_DOCUMENT_CAPABILITIES_INVALID', 'capabilities'),
+    ...(hints ? { hints } : {}),
+    proof: {
+      type: proofType,
+      verificationMethod: requireString(proof.verificationMethod, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.verificationMethod'),
+      createdAt: requireString(proof.createdAt, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.createdAt'),
+      signature: requireString(proof.signature, 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof.signature'),
+    },
+  };
+}
+
+export function parseDomainDocument(raw: unknown, expectations: DomainDocumentExpectations): DomainDocument {
+  const document = parseDomainDocumentShape(raw);
+  if (document.schema !== DOMAIN_DOCUMENT_SCHEMA) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_SCHEMA_INVALID', 'Unsupported Domain Document schema');
+  }
+  if (document.protocol.version !== (expectations.expectedProtocolVersion ?? DOMAIN_PROTOCOL_VERSION)) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_PROTOCOL_MISMATCH', 'Domain Document protocol version mismatch');
+  }
+  if (document.venue.moduleId !== expectations.expectedVenueModuleId) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_VENUE_MISMATCH', 'Domain Document venue module mismatch');
+  }
+  if (document.venue.namespace !== expectations.expectedVenueNamespace) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_NAMESPACE_MISMATCH', 'Domain Document venue namespace mismatch');
+  }
+
+  const verificationKey = document.publicKeys.find((key) => key.id === document.proof.verificationMethod);
+  if (!verificationKey) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Domain Document proof key not found');
+  }
+  const valid = verify(
+    null,
+    canonicalDomainDocumentPayload(document as unknown as Record<string, unknown>),
+    createPublicKey(verificationKey.publicKeyPem),
+    Buffer.from(document.proof.signature, 'base64'),
+  );
+  if (!valid) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_SIGNATURE_INVALID', 'Domain Document signature invalid');
+  }
+
+  return document;
+}

--- a/packages/server/src/core/domain/index.ts
+++ b/packages/server/src/core/domain/index.ts
@@ -1,0 +1,2 @@
+export * from './document.js';
+export * from './service.js';

--- a/packages/server/src/core/domain/service.ts
+++ b/packages/server/src/core/domain/service.ts
@@ -1,0 +1,352 @@
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+
+import { type UrucDb, schema } from '../database/index.js';
+import type { VenueModuleManifest } from '../plugin-platform/types.js';
+import {
+  DOMAIN_PROTOCOL_VERSION,
+  DomainDocumentError,
+  type DomainDocument,
+  parseDomainDocument,
+} from './document.js';
+
+export const DOMAIN_ATTACHMENT_REQUEST_SCHEMA = 'uruc.domain.attachment.request@v0';
+export const DOMAIN_ATTACHMENT_RECEIPT_SCHEMA = 'uruc.domain.attachment.receipt@v0';
+
+type FetchLike = typeof fetch;
+
+export interface DomainAttachmentServiceOptions {
+  fetch?: FetchLike;
+  timeoutMs?: number;
+  maxDocumentBytes?: number;
+  maxReceiptBytes?: number;
+  now?: () => Date;
+}
+
+export interface AttachVenueDomainInput {
+  cityId: string;
+  pluginId: string;
+  venue: VenueModuleManifest;
+}
+
+export interface DomainAttachmentCompactReceipt {
+  ok: boolean;
+  code: string;
+  cityId: string;
+  venueModuleId: string;
+  domainId?: string;
+  attachmentId?: string;
+}
+
+export interface DomainAttachmentResult {
+  status: 'attached' | 'failed' | 'skipped';
+  receipt: DomainAttachmentCompactReceipt;
+  document?: DomainDocument;
+}
+
+interface AttachmentReceipt {
+  schema: typeof DOMAIN_ATTACHMENT_RECEIPT_SCHEMA;
+  status: 'accepted' | 'rejected';
+  code: string;
+  receiptId?: string;
+  validUntil?: Date;
+  capabilities: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function asUrl(value: string, code: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('unsupported protocol');
+    return url.toString();
+  } catch {
+    throw new DomainDocumentError(code, `Invalid URL: ${value}`);
+  }
+}
+
+function resolveDocumentUrl(domain: { endpoint?: string; document?: string } | undefined): string {
+  if (!domain || typeof domain !== 'object') {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_URL_REQUIRED', 'Domain topology requires endpoint or document metadata');
+  }
+  const record = domain as Record<string, unknown>;
+  const document = stringValue(record.document);
+  if (document) return asUrl(document, 'DOMAIN_DOCUMENT_URL_INVALID');
+  const endpoint = stringValue(record.endpoint);
+  if (!endpoint) {
+    throw new DomainDocumentError('DOMAIN_DOCUMENT_URL_REQUIRED', 'Domain topology requires endpoint or document metadata');
+  }
+  return new URL('/.well-known/uruc-domain.json', asUrl(endpoint, 'DOMAIN_ENDPOINT_INVALID')).toString();
+}
+
+async function readLimitedText(response: Response, maxBytes: number): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      throw new DomainDocumentError('DOMAIN_RESPONSE_TOO_LARGE', 'Domain response is too large');
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseJson(text: string, code: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new DomainDocumentError(code, 'Domain response is not valid JSON');
+  }
+}
+
+function parseAttachmentReceipt(raw: unknown): AttachmentReceipt {
+  if (!isRecord(raw)) {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt');
+  }
+  if (raw.schema !== DOMAIN_ATTACHMENT_RECEIPT_SCHEMA) {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt schema');
+  }
+  if (raw.status !== 'accepted' && raw.status !== 'rejected') {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt status');
+  }
+  const code = stringValue(raw.code);
+  if (!code) {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt code');
+  }
+  const capabilities = raw.capabilities === undefined
+    ? []
+    : Array.isArray(raw.capabilities) && raw.capabilities.every((item) => typeof item === 'string' && item.trim() !== '')
+      ? raw.capabilities
+      : undefined;
+  if (!capabilities) {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt capabilities');
+  }
+  const validUntilValue = stringValue(raw.validUntil);
+  const validUntil = validUntilValue ? new Date(validUntilValue) : undefined;
+  if (validUntil && Number.isNaN(validUntil.getTime())) {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt validUntil');
+  }
+  return {
+    schema: DOMAIN_ATTACHMENT_RECEIPT_SCHEMA,
+    status: raw.status,
+    code,
+    receiptId: stringValue(raw.receiptId),
+    ...(validUntil ? { validUntil } : {}),
+    capabilities,
+  };
+}
+
+export class DomainAttachmentService {
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  private readonly maxDocumentBytes: number;
+  private readonly maxReceiptBytes: number;
+  private readonly now: () => Date;
+
+  constructor(
+    private readonly db: UrucDb,
+    options: DomainAttachmentServiceOptions = {},
+  ) {
+    this.fetchImpl = options.fetch ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? 3_000;
+    this.maxDocumentBytes = options.maxDocumentBytes ?? 64 * 1024;
+    this.maxReceiptBytes = options.maxReceiptBytes ?? 32 * 1024;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async attachVenueDomain(input: AttachVenueDomainInput): Promise<DomainAttachmentResult> {
+    if (input.venue.topology?.mode !== 'domain') {
+      return {
+        status: 'skipped',
+        receipt: {
+          ok: true,
+          code: 'LOCAL_TOPOLOGY',
+          cityId: input.cityId,
+          venueModuleId: input.venue.moduleId,
+        },
+      };
+    }
+
+    let document: DomainDocument | undefined;
+    let attachmentId: string | undefined;
+    try {
+      const documentUrl = resolveDocumentUrl(input.venue.topology.domain);
+      document = await this.fetchDomainDocument(documentUrl, input);
+      attachmentId = await this.insertAttachment({
+        status: 'pending',
+        input,
+        document,
+        documentUrl,
+        receiptCode: 'PENDING',
+        receipt: { ok: false, code: 'PENDING' },
+        capabilities: document.capabilities,
+      });
+
+      const attachmentReceipt = await this.requestAttachment(document, input);
+      const status = attachmentReceipt.status === 'accepted' ? 'attached' : 'failed';
+      const compact = {
+        ok: status === 'attached',
+        code: attachmentReceipt.code,
+        cityId: input.cityId,
+        venueModuleId: input.venue.moduleId,
+        domainId: document.domainId,
+        attachmentId,
+      };
+      await this.updateAttachment(attachmentId, {
+        status,
+        receiptCode: attachmentReceipt.code,
+        receipt: compact,
+        capabilities: attachmentReceipt.capabilities.length > 0 ? attachmentReceipt.capabilities : document.capabilities,
+        validUntil: attachmentReceipt.validUntil,
+      });
+      return {
+        status,
+        receipt: compact,
+        document,
+      };
+    } catch (error) {
+      const code = error instanceof DomainDocumentError ? error.code : 'DOMAIN_ATTACHMENT_FAILED';
+      const compact = {
+        ok: false,
+        code,
+        cityId: input.cityId,
+        venueModuleId: input.venue.moduleId,
+        ...(document ? { domainId: document.domainId } : {}),
+        ...(attachmentId ? { attachmentId } : {}),
+      };
+      if (attachmentId) {
+        await this.updateAttachment(attachmentId, {
+          status: 'failed',
+          receiptCode: code,
+          receipt: compact,
+          capabilities: document?.capabilities ?? [],
+        });
+      }
+      return {
+        status: 'failed',
+        receipt: compact,
+        ...(document ? { document } : {}),
+      };
+    }
+  }
+
+  private async fetchDomainDocument(documentUrl: string, input: AttachVenueDomainInput): Promise<DomainDocument> {
+    const response = await this.fetchWithTimeout(documentUrl, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new DomainDocumentError('DOMAIN_DOCUMENT_FETCH_FAILED', `Domain Document fetch failed with HTTP ${response.status}`);
+    }
+    return parseDomainDocument(parseJson(await readLimitedText(response, this.maxDocumentBytes), 'DOMAIN_DOCUMENT_JSON_INVALID'), {
+      expectedVenueModuleId: input.venue.moduleId,
+      expectedVenueNamespace: input.venue.namespace,
+      expectedProtocolVersion: DOMAIN_PROTOCOL_VERSION,
+    });
+  }
+
+  private async requestAttachment(document: DomainDocument, input: AttachVenueDomainInput): Promise<AttachmentReceipt> {
+    const response = await this.fetchWithTimeout(document.endpoints.attachment, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        schema: DOMAIN_ATTACHMENT_REQUEST_SCHEMA,
+        cityId: input.cityId,
+        domainId: document.domainId,
+        pluginId: input.pluginId,
+        venue: document.venue,
+        protocolVersion: document.protocol.version,
+        requestedCapabilities: document.capabilities,
+      }),
+    });
+    const receipt = parseAttachmentReceipt(parseJson(await readLimitedText(response, this.maxReceiptBytes), 'DOMAIN_ATTACHMENT_RECEIPT_JSON_INVALID'));
+    if (!response.ok && receipt.status !== 'rejected') {
+      throw new DomainDocumentError(receipt.code, `Domain attachment failed with HTTP ${response.status}`);
+    }
+    return receipt;
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, {
+        ...init,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new DomainDocumentError('DOMAIN_REQUEST_TIMEOUT', 'Domain request timed out');
+      }
+      throw new DomainDocumentError('DOMAIN_REQUEST_FAILED', 'Domain request failed');
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async insertAttachment(input: {
+    status: 'pending' | 'attached' | 'failed';
+    input: AttachVenueDomainInput;
+    document: DomainDocument;
+    documentUrl: string;
+    receiptCode: string;
+    receipt: unknown;
+    capabilities: string[];
+  }): Promise<string> {
+    const id = randomUUID();
+    const now = this.now();
+    await this.db.insert(schema.domainAttachments).values({
+      id,
+      status: input.status,
+      domainId: input.document.domainId,
+      cityId: input.input.cityId,
+      pluginId: input.input.pluginId,
+      venueModuleId: input.input.venue.moduleId,
+      venueNamespace: input.input.venue.namespace,
+      protocolVersion: input.document.protocol.version,
+      endpoint: input.document.endpoints.attachment,
+      documentUrl: input.documentUrl,
+      capabilities: JSON.stringify(input.capabilities),
+      receiptCode: input.receiptCode,
+      receipt: JSON.stringify(input.receipt),
+      createdAt: now,
+      updatedAt: now,
+    });
+    return id;
+  }
+
+  private async updateAttachment(id: string, input: {
+    status: 'attached' | 'failed' | 'detached';
+    receiptCode: string;
+    receipt: unknown;
+    capabilities: string[];
+    validUntil?: Date;
+  }): Promise<void> {
+    await this.db.update(schema.domainAttachments)
+      .set({
+        status: input.status,
+        capabilities: JSON.stringify(input.capabilities),
+        receiptCode: input.receiptCode,
+        receipt: JSON.stringify(input.receipt),
+        issuedAt: input.status === 'attached' ? this.now() : null,
+        validUntil: input.validUntil ?? null,
+        updatedAt: this.now(),
+      })
+      .where(eq(schema.domainAttachments.id, id));
+  }
+}

--- a/packages/server/src/core/domain/service.ts
+++ b/packages/server/src/core/domain/service.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { eq } from 'drizzle-orm';
 
 import { type UrucDb, schema } from '../database/index.js';
@@ -7,6 +7,7 @@ import {
   DOMAIN_PROTOCOL_VERSION,
   DomainDocumentError,
   type DomainDocument,
+  canonicalDomainDocumentPayload,
   parseDomainDocument,
 } from './document.js';
 
@@ -111,6 +112,13 @@ function parseJson(text: string, code: string): unknown {
   }
 }
 
+function requireJsonContentType(response: Response, code: string): void {
+  const mediaType = (response.headers.get('content-type') ?? '').toLowerCase().split(';', 1)[0].trim();
+  if (mediaType !== 'application/json' && !mediaType.endsWith('+json')) {
+    throw new DomainDocumentError(code, 'Domain response content-type is not JSON');
+  }
+}
+
 function parseAttachmentReceipt(raw: unknown): AttachmentReceipt {
   if (!isRecord(raw)) {
     throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt');
@@ -137,6 +145,9 @@ function parseAttachmentReceipt(raw: unknown): AttachmentReceipt {
   const validUntil = validUntilValue ? new Date(validUntilValue) : undefined;
   if (validUntil && Number.isNaN(validUntil.getTime())) {
     throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Invalid attachment receipt validUntil');
+  }
+  if (raw.status === 'accepted' && !validUntil) {
+    throw new DomainDocumentError('DOMAIN_ATTACHMENT_RECEIPT_INVALID', 'Accepted attachment receipt requires validUntil');
   }
   return {
     schema: DOMAIN_ATTACHMENT_RECEIPT_SCHEMA,
@@ -195,6 +206,9 @@ export class DomainAttachmentService {
       });
 
       const attachmentReceipt = await this.requestAttachment(document, input);
+      if (attachmentReceipt.status === 'accepted' && attachmentReceipt.validUntil && attachmentReceipt.validUntil <= this.now()) {
+        throw new DomainDocumentError('DOMAIN_ATTACHMENT_EXPIRED', 'Domain attachment receipt is expired');
+      }
       const status = attachmentReceipt.status === 'accepted' ? 'attached' : 'failed';
       const compact = {
         ok: status === 'attached',
@@ -247,6 +261,7 @@ export class DomainAttachmentService {
       method: 'GET',
       headers: { accept: 'application/json' },
     });
+    requireJsonContentType(response, 'DOMAIN_DOCUMENT_CONTENT_TYPE_INVALID');
     if (!response.ok) {
       throw new DomainDocumentError('DOMAIN_DOCUMENT_FETCH_FAILED', `Domain Document fetch failed with HTTP ${response.status}`);
     }
@@ -274,6 +289,7 @@ export class DomainAttachmentService {
         requestedCapabilities: document.capabilities,
       }),
     });
+    requireJsonContentType(response, 'DOMAIN_ATTACHMENT_RECEIPT_CONTENT_TYPE_INVALID');
     const receipt = parseAttachmentReceipt(parseJson(await readLimitedText(response, this.maxReceiptBytes), 'DOMAIN_ATTACHMENT_RECEIPT_JSON_INVALID'));
     if (!response.ok && receipt.status !== 'rejected') {
       throw new DomainDocumentError(receipt.code, `Domain attachment failed with HTTP ${response.status}`);
@@ -321,6 +337,9 @@ export class DomainAttachmentService {
       protocolVersion: input.document.protocol.version,
       endpoint: input.document.endpoints.attachment,
       documentUrl: input.documentUrl,
+      documentHash: createHash('sha256')
+        .update(canonicalDomainDocumentPayload(input.document as unknown as Record<string, unknown>))
+        .digest('hex'),
       capabilities: JSON.stringify(input.capabilities),
       receiptCode: input.receiptCode,
       receipt: JSON.stringify(input.receipt),

--- a/packages/server/src/core/plugin-platform/__tests__/host.test.ts
+++ b/packages/server/src/core/plugin-platform/__tests__/host.test.ts
@@ -957,7 +957,7 @@ export default {
     await host.stopAll();
   });
 
-  it('does not let city config override venue domain metadata from the package manifest', async () => {
+  it('lets city config point at a selected domain without changing venue identity', async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-override-'));
     tempDirs.push(tempRoot);
 
@@ -1019,9 +1019,13 @@ export default {
       declaration: 'domain_optional',
       mode: 'domain',
       domain: {
-        endpoint: 'https://domain.example/acme',
-        document: 'https://domain.example/.well-known/uruc-domain.json',
+        endpoint: 'https://city-config.example/override',
+        document: 'https://city-config.example/override-document.json',
       },
+    });
+    expect(lock.plugins['acme.domain-override']?.venue).toMatchObject({
+      moduleId: 'acme.domain-override',
+      namespace: 'acme.domain-override',
     });
 
     const hooks = new HookRegistry();
@@ -1033,16 +1037,16 @@ export default {
       declaration: 'domain_optional',
       mode: 'domain',
       domain: {
-        endpoint: 'https://domain.example/acme',
-        document: 'https://domain.example/.well-known/uruc-domain.json',
+        endpoint: 'https://city-config.example/override',
+        document: 'https://city-config.example/override-document.json',
       },
     });
     expect(host.getPluginDiagnostics().find((item) => item.pluginId === 'acme.domain-override')?.venue?.topology).toEqual({
       declaration: 'domain_optional',
       mode: 'domain',
       domain: {
-        endpoint: 'https://domain.example/acme',
-        document: 'https://domain.example/.well-known/uruc-domain.json',
+        endpoint: 'https://city-config.example/override',
+        document: 'https://city-config.example/override-document.json',
       },
     });
 

--- a/packages/server/src/core/plugin-platform/__tests__/host.test.ts
+++ b/packages/server/src/core/plugin-platform/__tests__/host.test.ts
@@ -1053,6 +1053,68 @@ export default {
     await host.stopAll();
   });
 
+  it('lets city config select domain mode with only a Domain Document URL', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-document-'));
+    tempDirs.push(tempRoot);
+
+    const pluginPath = path.join(tempRoot, 'plugins', 'domain-topology-document');
+    const configPath = path.join(tempRoot, 'uruc.city.json');
+    const lockPath = path.join(tempRoot, 'uruc.city.lock.json');
+    const pluginStoreDir = path.join(tempRoot, '.uruc', 'plugins');
+
+    await createPluginPackage(pluginPath, {
+      pluginId: 'acme.domain-document',
+      packageName: '@acme/plugin-domain-document',
+      version: '1.0.0',
+      publisher: 'acme',
+      venue: {
+        moduleId: 'acme.domain-document',
+        namespace: 'acme.domain-document',
+        topology: {
+          mode: 'domain_optional',
+        },
+      },
+    });
+    await writeCityConfig(configPath, {
+      apiVersion: 2,
+      approvedPublishers: ['acme'],
+      pluginStoreDir,
+      sources: [],
+      plugins: {
+        'acme.domain-document': {
+          pluginId: 'acme.domain-document',
+          packageName: '@acme/plugin-domain-document',
+          enabled: true,
+          permissionsGranted: [],
+          devOverridePath: pluginPath,
+          topology: {
+            mode: 'domain',
+            domain: {
+              document: 'https://city-config.example/domain-document.json',
+            },
+          } as { mode: 'domain' },
+        },
+      },
+    });
+
+    const host = new PluginPlatformHost({
+      configPath,
+      lockPath,
+      packageRoot: process.cwd(),
+      pluginStoreDir,
+    });
+
+    await host.syncLockFile();
+    const lock = await readCityLock(lockPath);
+    expect(lock.plugins['acme.domain-document']?.venue?.topology).toEqual({
+      declaration: 'domain_optional',
+      mode: 'domain',
+      domain: {
+        document: 'https://city-config.example/domain-document.json',
+      },
+    });
+  });
+
   it('keeps a domain-optional venue local when city config selects local mode', async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-plugin-host-venue-topology-domain-local-'));
     tempDirs.push(tempRoot);

--- a/packages/server/src/core/plugin-platform/inspection.ts
+++ b/packages/server/src/core/plugin-platform/inspection.ts
@@ -93,8 +93,8 @@ function resolveVenueTopology(
     ...(declared.domain ?? {}),
     ...(pluginConfig.topology?.domain ?? {}),
   };
-  if (requestedMode === 'domain' && !domain.endpoint) {
-    throw new Error(`Plugin ${pluginId} domain topology requires endpoint metadata`);
+  if (requestedMode === 'domain' && !domain.endpoint && !domain.document) {
+    throw new Error(`Plugin ${pluginId} domain topology requires endpoint or document metadata`);
   }
 
   return {

--- a/packages/server/src/core/plugin-platform/inspection.ts
+++ b/packages/server/src/core/plugin-platform/inspection.ts
@@ -89,7 +89,10 @@ function resolveVenueTopology(
     throw new Error(`Plugin ${pluginId} requires domain topology config`);
   }
 
-  const domain = declared.domain ?? {};
+  const domain = {
+    ...(declared.domain ?? {}),
+    ...(pluginConfig.topology?.domain ?? {}),
+  };
   if (requestedMode === 'domain' && !domain.endpoint) {
     throw new Error(`Plugin ${pluginId} domain topology requires endpoint metadata`);
   }

--- a/packages/server/src/core/plugin-platform/types.ts
+++ b/packages/server/src/core/plugin-platform/types.ts
@@ -57,6 +57,10 @@ export interface CityPluginSpec {
   devOverridePath?: string;
   topology?: {
     mode: VenueRuntimeTopologyMode;
+    domain?: {
+      endpoint?: string;
+      document?: string;
+    };
   };
   config?: Record<string, unknown>;
 }


### PR DESCRIPTION
Closes #10

## Implementation
- Adds a core Domain Document parser/verifier for uruc.domain.document@v0, including endpoint/domain/venue/protocol/capability/hints validation and Ed25519 proof verification.
- Adds DomainAttachmentService for the City-to-Domain attachment handshake: fetch Domain Document with timeout/size limits, send attachment request, and store auditable domain_attachments records with compact receipt codes.
- Lets city config provide selected domain endpoint/document metadata for domain runtime topology without changing package identity, module id, or namespace.
- Updates English and Chinese docs for Domain Document/attachment boundaries.

## Checks
- npm run test --workspace=packages/server -- src/core/domain/__tests__/domain-attachment.test.ts src/core/plugin-platform/__tests__/host.test.ts src/core/plugin-platform/__tests__/inspection.test.ts
- npm run docs:check
- npm run build --workspace=packages/server
- git diff --check

## Not in scope
- No signed city-to-domain request dispatch envelope; that is #11.
- No federation document or trust-policy skeleton; that is #12.
- No Venue business synchronization and no Venue-domain state protocol.

## Unlocks
- This creates the Domain Document and attachment state needed for #11, but #11 still needs signed envelope dispatch and receipt audit work.