### PR TITLE
feat: add signed city-to-domain dispatch

### DIFF
--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -199,8 +199,9 @@ Current WebSocket behavior in `core/server/ws-gateway.ts`:
 5. Resolve the command schema from `HookRegistry`.
 6. Enforce same-resident action lease requirements before dispatch.
 7. For venue requests with `protocol.request.requiredCapabilities`, check active permission credentials and approval policy before dispatch. Missing grantable permission returns `PERMISSION_REQUIRED` with `nextAction: "require_approval"`; explicitly forbidden or unscoped legacy confirmation requests return `PERMISSION_DENIED`.
-8. Dispatch the command through `hooks.handleWSCommand(...)`.
-9. Push session-state updates when city/location/action lease state changes.
+8. For domain topology venues with an active attachment, wrap the authorized request in a signed City-to-Domain dispatch envelope and record the Domain receipt in `domain_dispatch_audits`.
+9. For local topology venues, dispatch the command through `hooks.handleWSCommand(...)`.
+10. Push session-state updates when city/location/action lease state changes.
 
 Session state is currently tracked by `AgentSessionService`, which records:
 
@@ -339,6 +340,8 @@ Local modules stay local by default. Domain-capable modules can expose endpoint/
 Domain attachment records are core-owned audit state. Each record stores status (`pending`, `attached`, `failed`, or `detached`), domain id, city id, plugin id, venue module id, venue namespace, protocol version, endpoint/document URLs, Domain Document hash, capabilities, receipt code, receipt JSON, and timestamps. Attachment failure returns stable compact receipt codes and must not make later request dispatch appear successful.
 
 Domain Document v0 uses schema id `uruc.domain.document@v0` and protocol version `uruc-domain-v0`. The Ed25519 proof signs the sorted JSON document without the `proof` object and must declare the exact covered top-level fields (`capabilities`, `domainId`, `endpoints`, `hints`, `protocol`, `publicKeys`, `schema`, and `venue`). Fetch and receipt parsing require JSON content types, bounded response sizes, parseable JSON, and stable compact error codes.
+
+Signed domain dispatch is limited to attached domain topology. City Core performs its normal action lease and permission checks first, then signs an envelope containing the current request id/type/payload, resident id, city id, venue module id/namespace, capability and permission credential refs, timestamps, nonce, and attachment/domain refs. Domain receipts must be signed by a key from the attached Domain Document and must echo the envelope hash. City Core stores both the pre-dispatch envelope and final compact receipt in `domain_dispatch_audits`. Local topology continues local handling; missing, failed, expired, or detached attachments cannot silently fall back to domain success. Federation and cross-city trust policy remain out of scope until #12, and City Core still does not interpret Venue business payloads.
 
 ### Runtime context exposed to backend venue modules
 

--- a/docs/core-architecture.zh-CN.md
+++ b/docs/core-architecture.zh-CN.md
@@ -199,8 +199,9 @@
 5. 从 `HookRegistry` 取出命令 schema。
 6. 在正式分发前，执行同一 resident 的 action lease requirement。
 7. 如果 Venue request 声明了 `protocol.request.requiredCapabilities`，在分发前检查 active permission credential 和 approval policy。缺少可批准的 permission 时返回 `PERMISSION_REQUIRED` 与 `nextAction: "require_approval"`；显式禁止或未声明 capability 的 legacy confirmation request 返回 `PERMISSION_DENIED`。
-8. 通过 `hooks.handleWSCommand(...)` 分发命令。
-9. 当城市 / 地点 / action lease 状态变化时，向连接推送 session-state 更新。
+8. 对已有 active attachment 的 domain topology 场馆，把已授权请求包装成 signed City-to-Domain dispatch envelope，并把 Domain receipt 记录到 `domain_dispatch_audits`。
+9. 对 local topology 场馆，通过 `hooks.handleWSCommand(...)` 分发命令。
+10. 当城市 / 地点 / action lease 状态变化时，向连接推送 session-state 更新。
 
 会话状态当前由 `AgentSessionService` 管理，记录内容包括：
 
@@ -339,6 +340,8 @@ Local module 默认保持 local。Domain-capable module 可以暴露 endpoint/do
 Domain attachment record 是 City Core 拥有的 audit state。每条记录包含状态（`pending`、`attached`、`failed` 或 `detached`）、domain id、city id、plugin id、venue module id、venue namespace、protocol version、endpoint/document URLs、Domain Document hash、capabilities、receipt code、receipt JSON 和时间戳。Attachment 失败会返回稳定的紧凑 receipt code，且不能让后续 request dispatch 假装成功。
 
 Domain Document v0 使用 schema id `uruc.domain.document@v0` 和 protocol version `uruc-domain-v0`。Ed25519 proof 签名的是移除 `proof` 对象后的 sorted JSON document，并且必须声明精确的顶层 covered fields（`capabilities`、`domainId`、`endpoints`、`hints`、`protocol`、`publicKeys`、`schema` 和 `venue`）。Fetch 和 receipt 解析要求 JSON content type、有界 response size、可解析 JSON，以及稳定的紧凑错误码。
+
+Signed domain dispatch 只适用于已 attached 的 domain topology。City Core 会先执行现有 action lease 和 permission checks，然后签名一个 envelope，包含当前 request id/type/payload、resident id、city id、venue module id/namespace、capability 与 permission credential refs、timestamps、nonce，以及 attachment/domain refs。Domain receipt 必须由 attached Domain Document 中的 key 签名，并且必须回显 envelope hash。City Core 会把 pre-dispatch envelope 和最终紧凑 receipt 都写入 `domain_dispatch_audits`。Local topology 继续本地处理；missing、failed、expired 或 detached attachment 不能静默伪装成 domain success。Federation 和跨城 trust policy 仍属于 #12，City Core 仍不理解 Venue 业务 payload。
 
 ### 后端 Venue Module 可见的运行时上下文
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -150,7 +150,9 @@ Venue metadata:
 
 City config may select runtime topology with `plugins[pluginId].topology.mode` as `local` or `domain`. `domain_optional` modules default to local unless city config selects domain. `domain_required` modules fail resolution until city config selects domain. For domain runtime mode, city config may also provide `plugins[pluginId].topology.domain.endpoint` and `plugins[pluginId].topology.domain.document` to point at the chosen Domain Service and Domain Document without changing package identity, module id, or namespace.
 
-Domain Document and attachment handshake support is limited to connection metadata. City Core fetches and validates the Domain Document, sends an attachment request, and records an auditable attachment receipt with the Domain Document hash. The v0 proof signs the sorted JSON document without the `proof` object and must declare the exact covered top-level fields. It does not send signed request dispatch envelopes; that belongs to #11. It does not define federation; that belongs to #12. Venue business synchronization remains owned by venue/domain protocols, not City Core.
+Domain Document and attachment handshake support is limited to connection metadata. City Core fetches and validates the Domain Document, sends an attachment request, and records an auditable attachment receipt with the Domain Document hash. The v0 proof signs the sorted JSON document without the `proof` object and must declare the exact covered top-level fields.
+
+For domain runtime mode, request dispatch is City-to-Domain only after the attachment is `attached`. City Core runs the same action lease and permission checks as local requests, signs an envelope around the request/event payload and proof refs, posts it to the Domain dispatch endpoint, verifies the signed Domain receipt, and stores audit records. The envelope is a transport/audit wrapper; City Core does not parse or synchronize Venue business state. Federation remains #12.
 
 Useful optional fields:
 

--- a/docs/plugin-development.zh-CN.md
+++ b/docs/plugin-development.zh-CN.md
@@ -150,7 +150,9 @@ Venue metadata：
 
 City config 可以通过 `plugins[pluginId].topology.mode` 选择 `local` 或 `domain` runtime topology。`domain_optional` 默认 local，除非 city config 选择 domain。`domain_required` 在 city config 选择 domain 前会解析失败。对于 domain runtime mode，city config 也可以提供 `plugins[pluginId].topology.domain.endpoint` 和 `plugins[pluginId].topology.domain.document`，用于指向被选择的 Domain Service 和 Domain Document，但不会改变 package identity、module id 或 namespace。
 
-Domain Document 和 attachment handshake 支持仅限连接 metadata。City Core 会拉取并校验 Domain Document，发送 attachment request，并记录带有 Domain Document hash 的可审计 attachment receipt。v0 proof 签名的是移除 `proof` 对象后的 sorted JSON document，并且必须声明精确的顶层 covered fields。它不会发送 signed request dispatch envelope；那属于 #11。它不会定义 federation；那属于 #12。Venue 业务同步仍由 venue/domain protocols 拥有，不属于 City Core。
+Domain Document 和 attachment handshake 支持仅限连接 metadata。City Core 会拉取并校验 Domain Document，发送 attachment request，并记录带有 Domain Document hash 的可审计 attachment receipt。v0 proof 签名的是移除 `proof` 对象后的 sorted JSON document，并且必须声明精确的顶层 covered fields。
+
+对于 domain runtime mode，只有 attachment 处于 `attached` 后才会走 City-to-Domain request dispatch。City Core 会执行与 local request 相同的 action lease 和 permission checks，把 request/event payload 与 proof refs 包装成 signed envelope，POST 到 Domain dispatch endpoint，校验 signed Domain receipt，并写入 audit records。Envelope 只是 transport/audit wrapper；City Core 不解析或同步 Venue 业务状态。Federation 仍属于 #12。
 
 常用可选字段：
 

--- a/packages/server/src/core/database/index.ts
+++ b/packages/server/src/core/database/index.ts
@@ -88,13 +88,36 @@ export function createDb(dbPath: string = getDbPath()) {
     venue_namespace TEXT NOT NULL,
     protocol_version TEXT NOT NULL,
     endpoint TEXT NOT NULL,
+    dispatch_endpoint TEXT,
     document_url TEXT NOT NULL,
     document_hash TEXT NOT NULL,
+    public_keys TEXT NOT NULL DEFAULT '[]',
     capabilities TEXT NOT NULL,
     receipt_code TEXT NOT NULL,
     receipt TEXT NOT NULL,
     issued_at INTEGER,
     valid_until INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+
+  db.run(sql`CREATE TABLE IF NOT EXISTS domain_dispatch_audits (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    attachment_id TEXT NOT NULL REFERENCES domain_attachments(id),
+    city_id TEXT NOT NULL,
+    domain_id TEXT NOT NULL,
+    resident_id TEXT NOT NULL,
+    plugin_id TEXT NOT NULL,
+    venue_module_id TEXT NOT NULL,
+    venue_namespace TEXT NOT NULL,
+    command TEXT NOT NULL,
+    request_type TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    envelope_hash TEXT NOT NULL,
+    envelope TEXT NOT NULL,
+    receipt_code TEXT NOT NULL,
+    receipt TEXT NOT NULL,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
   )`);
@@ -111,6 +134,7 @@ export function createDb(dbPath: string = getDbPath()) {
   db.run(sql`CREATE INDEX IF NOT EXISTS permission_credentials_resident_status ON permission_credentials(resident_id, status)`);
   db.run(sql`CREATE INDEX IF NOT EXISTS principal_backed_residents_principal ON principal_backed_residents(accountable_principal_id)`);
   db.run(sql`CREATE INDEX IF NOT EXISTS domain_attachments_venue_status ON domain_attachments(plugin_id, venue_module_id, status)`);
+  db.run(sql`CREATE INDEX IF NOT EXISTS domain_dispatch_audits_resident_status ON domain_dispatch_audits(resident_id, status)`);
 
   return db;
 }

--- a/packages/server/src/core/database/schema.ts
+++ b/packages/server/src/core/database/schema.ts
@@ -2,7 +2,7 @@
  * Core Database Schema — only tables owned by core modules.
  *
  * Plugin tables are defined in each plugin's own schema file.
- * Core tables: users, pending_registrations, oauth_accounts, agents, permission_credentials, principal_backed_residents, domain_attachments, action_logs
+ * Core tables: users, pending_registrations, oauth_accounts, agents, permission_credentials, principal_backed_residents, domain_attachments, domain_dispatch_audits, action_logs
  */
 
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
@@ -86,13 +86,36 @@ export const domainAttachments = sqliteTable('domain_attachments', {
   venueNamespace: text('venue_namespace').notNull(),
   protocolVersion: text('protocol_version').notNull(),
   endpoint: text('endpoint').notNull(),
+  dispatchEndpoint: text('dispatch_endpoint'),
   documentUrl: text('document_url').notNull(),
   documentHash: text('document_hash').notNull(),
+  publicKeys: text('public_keys').notNull().default('[]'),
   capabilities: text('capabilities').notNull(),
   receiptCode: text('receipt_code').notNull(),
   receipt: text('receipt').notNull(),
   issuedAt: integer('issued_at', { mode: 'timestamp' }),
   validUntil: integer('valid_until', { mode: 'timestamp' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+});
+
+export const domainDispatchAudits = sqliteTable('domain_dispatch_audits', {
+  id: text('id').primaryKey(),
+  status: text('status', { enum: ['pending', 'delivered', 'failed'] }).notNull(),
+  attachmentId: text('attachment_id').notNull().references(() => domainAttachments.id),
+  cityId: text('city_id').notNull(),
+  domainId: text('domain_id').notNull(),
+  residentId: text('resident_id').notNull(),
+  pluginId: text('plugin_id').notNull(),
+  venueModuleId: text('venue_module_id').notNull(),
+  venueNamespace: text('venue_namespace').notNull(),
+  command: text('command').notNull(),
+  requestType: text('request_type').notNull(),
+  endpoint: text('endpoint').notNull(),
+  envelopeHash: text('envelope_hash').notNull(),
+  envelope: text('envelope').notNull(),
+  receiptCode: text('receipt_code').notNull(),
+  receipt: text('receipt').notNull(),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 });

--- a/packages/server/src/core/domain/__tests__/domain-dispatch.test.ts
+++ b/packages/server/src/core/domain/__tests__/domain-dispatch.test.ts
@@ -19,6 +19,8 @@ import { canonicalDomainDocumentPayload } from '../document.js';
 import {
   DOMAIN_DISPATCH_ENVELOPE_SCHEMA,
   DOMAIN_DISPATCH_RECEIPT_SCHEMA,
+  DOMAIN_DISPATCH_ENVELOPE_SIGNED_FIELDS,
+  DOMAIN_DISPATCH_RECEIPT_SIGNED_FIELDS,
   DomainDispatchService,
   canonicalDomainDispatchEnvelopePayload,
   canonicalDomainDispatchReceiptPayload,
@@ -122,6 +124,7 @@ function domainFixture() {
         verificationMethod: 'domain-key-1',
         createdAt: '2026-05-03T00:00:01.000Z',
         canonicalization: 'uruc-domain-dispatch-receipt-v0-sorted-json-without-proof',
+        covered: [...DOMAIN_DISPATCH_RECEIPT_SIGNED_FIELDS],
         signature: sign(null, canonicalDomainDispatchReceiptPayload(receipt), privateKey).toString('base64'),
       },
     };
@@ -179,8 +182,14 @@ describe('Domain signed dispatch', () => {
           receivedEnvelopes.push(envelope);
           expect(envelope).toMatchObject({
             schema: DOMAIN_DISPATCH_ENVELOPE_SCHEMA,
+            audit: { id: expect.any(String) },
             city: { id: 'city.alpha' },
             domain: { id: 'domain.acme.social' },
+            attachment: {
+              id: expect.any(String),
+              documentUrl: `${baseUrl}/.well-known/uruc-domain.json`,
+              documentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+            },
             resident: { id: expect.any(String) },
             venue: {
               pluginId: 'acme.social',
@@ -204,13 +213,19 @@ describe('Domain signed dispatch', () => {
             createPublicKey(envelope.city.publicKeyPem),
             Buffer.from(envelope.proof.signature, 'base64'),
           )).toBe(true);
+          expect(envelope.proof.covered).toEqual([...DOMAIN_DISPATCH_ENVELOPE_SIGNED_FIELDS]);
           const receipt = {
             schema: DOMAIN_DISPATCH_RECEIPT_SCHEMA,
+            domainId: 'domain.acme.social',
+            cityId: 'city.alpha',
+            auditId: envelope.audit.id,
+            requestId: envelope.request.id,
             status: 'delivered',
             code: 'DOMAIN_DELIVERED',
             receiptId: 'domain-receipt-1',
             envelopeHash: envelope.envelopeHash,
             eventRef: 'domain-event-1',
+            issuedAt: '2026-05-03T00:00:01.000Z',
           };
           res.setHeader('content-type', 'application/json');
           res.end(JSON.stringify(fixture.signedReceipt(receipt)));
@@ -345,6 +360,132 @@ describe('Domain signed dispatch', () => {
     }
   });
 
+  it('runs City Core runtime policy hooks before creating a domain envelope', async () => {
+    const fixture = domainFixture();
+    let dispatchCalls = 0;
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(fixture.signedDocument(baseUrl)));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'accepted',
+          code: 'ATTACHED',
+          receiptId: 'attach-policy',
+          validUntil: '2026-06-03T00:00:00.000Z',
+        }));
+        return;
+      }
+      if (req.url === '/uruc/dispatch' && req.method === 'POST') {
+        dispatchCalls += 1;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({}));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const attachment = new DomainAttachmentService(db);
+      await attachment.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.policy',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: { endpoint: baseUrl },
+          },
+        },
+      });
+
+      const domainDispatch = new DomainDispatchService(db, {
+        cityId: 'city.alpha',
+        pluginPlatform: {
+          listPlugins: () => [{
+            name: 'acme.policy',
+            version: '1.0.0',
+            started: true,
+            state: 'active',
+            venue: {
+              moduleId: 'acme.social',
+              namespace: 'acme.social',
+              topology: {
+                declaration: 'domain_required',
+                mode: 'domain',
+                domain: { endpoint: baseUrl },
+              },
+            },
+          }],
+          getPluginDiagnostics: () => [],
+          listFrontendPlugins: async () => [],
+          readFrontendAsset: async () => null,
+        },
+      });
+      services.register('domain-dispatch', domainDispatch);
+      hooks.before('ws.command', (hookCtx) => {
+        if ((hookCtx as any).command !== 'acme.policy.write@v1') return;
+        Object.assign(hookCtx as any, {
+          cancelled: true,
+          blockReason: {
+            error: 'Blocked by test policy.',
+            code: 'COMMAND_BLOCKED_BY_POLICY',
+          },
+        });
+      });
+      const handler = vi.fn();
+      hooks.registerWSCommand('acme.policy.write@v1', handler, {
+        type: 'acme.policy.write@v1',
+        description: 'Domain write blocked by policy.',
+        pluginName: 'acme.policy',
+        params: {},
+        controlPolicy: { controllerRequired: false },
+        protocol: {
+          subject: 'resident',
+          request: { type: 'acme.policy.write.request@v1' },
+          venue: { id: 'acme.social', moduleId: 'acme.social' },
+        },
+      });
+
+      const user = await auth.register('domain-policy-user', 'domain-policy@example.com', 'secret-123');
+      const sent: SentEnvelope[] = [];
+      const client = createClient(sent);
+      (gateway as any).clients.set('client-policy', client);
+      await (gateway as any).handleAgentAuth('client-policy', client, {
+        id: 'auth-policy',
+        type: 'auth',
+        payload: signToken(user.id, 'user'),
+      });
+
+      sent.length = 0;
+      await (gateway as any).handleMessage('client-policy', {
+        id: 'write-policy',
+        type: 'acme.policy.write@v1',
+        payload: { text: 'blocked' },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(dispatchCalls).toBe(0);
+      expect(sent.at(-1)).toMatchObject({
+        id: 'write-policy',
+        type: 'error',
+        payload: { code: 'COMMAND_BLOCKED_BY_POLICY' },
+      });
+      expect(await db.select().from(schema.domainDispatchAudits)).toHaveLength(0);
+    } finally {
+      await close(server);
+    }
+  });
+
   it('keeps local topology on the local handler and does not create domain audit records', async () => {
     const domainDispatch = new DomainDispatchService(db, {
       cityId: 'city.alpha',
@@ -409,6 +550,75 @@ describe('Domain signed dispatch', () => {
       type: 'result',
       payload: { local: true },
     });
+    expect(await db.select().from(schema.domainDispatchAudits)).toHaveLength(0);
+  });
+
+  it('does not dispatch from an attachment unless the plugin runtime topology is domain', async () => {
+    await db.insert(schema.domainAttachments).values({
+      id: 'attached-local-1',
+      status: 'attached',
+      domainId: 'domain.acme.local',
+      cityId: 'city.alpha',
+      pluginId: 'acme.local-attached',
+      venueModuleId: 'acme.local-attached',
+      venueNamespace: 'acme.local-attached',
+      protocolVersion: 'uruc-domain-v0',
+      endpoint: 'https://domain.example/attach',
+      dispatchEndpoint: 'https://domain.example/dispatch',
+      documentUrl: 'https://domain.example/.well-known/uruc-domain.json',
+      documentHash: '0'.repeat(64),
+      publicKeys: '[]',
+      capabilities: '[]',
+      receiptCode: 'ATTACHED',
+      receipt: JSON.stringify({ ok: true, code: 'ATTACHED' }),
+      issuedAt: new Date('2026-05-03T00:00:00.000Z'),
+      validUntil: new Date('2026-06-03T00:00:00.000Z'),
+      createdAt: new Date('2026-05-03T00:00:00.000Z'),
+      updatedAt: new Date('2026-05-03T00:00:00.000Z'),
+    });
+
+    const domainDispatch = new DomainDispatchService(db, {
+      cityId: 'city.alpha',
+      fetch: async () => {
+        throw new Error('local topology must not call the domain network');
+      },
+      pluginPlatform: {
+        listPlugins: () => [{
+          name: 'acme.local-attached',
+          version: '1.0.0',
+          started: true,
+          state: 'active',
+          venue: {
+            moduleId: 'acme.local-attached',
+            namespace: 'acme.local-attached',
+            topology: {
+              declaration: 'local',
+              mode: 'local',
+            },
+          },
+        }],
+        getPluginDiagnostics: () => [],
+        listFrontendPlugins: async () => [],
+        readFrontendAsset: async () => null,
+      },
+    });
+
+    await expect(domainDispatch.dispatchVenueRequest({
+      schema: {
+        type: 'acme.local-attached.write@v1',
+        description: 'Local write.',
+        pluginName: 'acme.local-attached',
+        params: {},
+        protocol: {
+          subject: 'resident',
+          request: { type: 'acme.local-attached.write.request@v1' },
+          venue: { id: 'acme.local-attached', moduleId: 'acme.local-attached' },
+        },
+      },
+      msg: { id: 'local-attached-a', type: 'acme.local-attached.write@v1', payload: {} },
+      session: { userId: 'user-a', agentId: 'resident-a', agentName: 'Resident A', role: 'agent' } as any,
+      permissionCredentials: [],
+    })).resolves.toEqual({ status: 'skipped' });
     expect(await db.select().from(schema.domainDispatchAudits)).toHaveLength(0);
   });
 
@@ -629,6 +839,135 @@ describe('Domain signed dispatch', () => {
       expect(audits[0]).toMatchObject({
         status: 'failed',
         receiptCode: 'DOMAIN_DISPATCH_RECEIPT_CONTENT_TYPE_INVALID',
+      });
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('rejects signed domain receipts whose semantic refs do not match the dispatch audit', async () => {
+    const fixture = domainFixture();
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(fixture.signedDocument(baseUrl)));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'accepted',
+          code: 'ATTACHED',
+          receiptId: 'attach-mismatch',
+          validUntil: '2026-06-03T00:00:00.000Z',
+        }));
+        return;
+      }
+      if (req.url === '/uruc/dispatch' && req.method === 'POST') {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          const envelope = JSON.parse(body);
+          const receipt = {
+            schema: DOMAIN_DISPATCH_RECEIPT_SCHEMA,
+            domainId: 'domain.attacker',
+            cityId: 'city.alpha',
+            auditId: envelope.audit.id,
+            requestId: envelope.request.id,
+            status: 'delivered',
+            code: 'DOMAIN_DELIVERED',
+            receiptId: 'domain-receipt-mismatch',
+            envelopeHash: envelope.envelopeHash,
+            eventRef: null,
+            issuedAt: '2026-05-03T00:00:01.000Z',
+          };
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify(fixture.signedReceipt(receipt)));
+        });
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const attachment = new DomainAttachmentService(db);
+      await attachment.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.mismatch',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: { endpoint: baseUrl },
+          },
+        },
+      });
+
+      const domainDispatch = new DomainDispatchService(db, {
+        cityId: 'city.alpha',
+        pluginPlatform: {
+          listPlugins: () => [{
+            name: 'acme.mismatch',
+            version: '1.0.0',
+            started: true,
+            state: 'active',
+            venue: {
+              moduleId: 'acme.social',
+              namespace: 'acme.social',
+              topology: {
+                declaration: 'domain_required',
+                mode: 'domain',
+                domain: { endpoint: baseUrl },
+              },
+            },
+          }],
+          getPluginDiagnostics: () => [],
+          listFrontendPlugins: async () => [],
+          readFrontendAsset: async () => null,
+        },
+        now: () => new Date('2026-05-03T00:00:00.000Z'),
+      });
+
+      const result = await domainDispatch.dispatchVenueRequest({
+        schema: {
+          type: 'acme.mismatch.write@v1',
+          description: 'Domain write.',
+          pluginName: 'acme.mismatch',
+          params: {},
+          protocol: {
+            subject: 'resident',
+            request: { type: 'acme.mismatch.write.request@v1' },
+            venue: { id: 'acme.social', moduleId: 'acme.social' },
+          },
+        },
+        msg: { id: 'write-mismatch', type: 'acme.mismatch.write@v1', payload: {} },
+        session: { userId: 'user-a', agentId: 'resident-a', agentName: 'Resident A', role: 'agent' } as any,
+        permissionCredentials: [],
+      });
+
+      expect(result).toMatchObject({
+        status: 'failed',
+        receipt: {
+          ok: false,
+          code: 'DOMAIN_DISPATCH_RECEIPT_DOMAIN_MISMATCH',
+          cityId: 'city.alpha',
+          domainId: 'domain.acme.social',
+          venueModuleId: 'acme.social',
+        },
+      });
+      const audits = await db.select().from(schema.domainDispatchAudits);
+      expect(audits).toHaveLength(1);
+      expect(audits[0]).toMatchObject({
+        status: 'failed',
+        receiptCode: 'DOMAIN_DISPATCH_RECEIPT_DOMAIN_MISMATCH',
       });
     } finally {
       await close(server);

--- a/packages/server/src/core/domain/__tests__/domain-dispatch.test.ts
+++ b/packages/server/src/core/domain/__tests__/domain-dispatch.test.ts
@@ -1,0 +1,637 @@
+import { createServer, type Server } from 'http';
+import { AddressInfo } from 'net';
+import { generateKeyPairSync, sign, verify, createPublicKey } from 'crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../auth/email.js', () => ({
+  sendVerificationEmail: vi.fn(async () => undefined),
+}));
+
+import { AuthService } from '../../auth/service.js';
+import { createDb, schema } from '../../database/index.js';
+import { PermissionCredentialService } from '../../permission/service.js';
+import { HookRegistry } from '../../plugin-system/hook-registry.js';
+import { ServiceRegistry } from '../../plugin-system/service-registry.js';
+import { signToken } from '../../server/middleware.js';
+import { WSGateway } from '../../server/ws-gateway.js';
+import { DomainAttachmentService } from '../service.js';
+import { canonicalDomainDocumentPayload } from '../document.js';
+import {
+  DOMAIN_DISPATCH_ENVELOPE_SCHEMA,
+  DOMAIN_DISPATCH_RECEIPT_SCHEMA,
+  DomainDispatchService,
+  canonicalDomainDispatchEnvelopePayload,
+  canonicalDomainDispatchReceiptPayload,
+} from '../dispatch.js';
+
+interface SentEnvelope {
+  id?: string;
+  type: string;
+  payload?: Record<string, unknown>;
+}
+
+function createSocket(sent: SentEnvelope[]) {
+  return {
+    readyState: 1,
+    send(data: string) {
+      sent.push(JSON.parse(data) as SentEnvelope);
+    },
+    close: vi.fn(),
+    ping: vi.fn(),
+    terminate: vi.fn(),
+  } as any;
+}
+
+function createClient(sent: SentEnvelope[]) {
+  return {
+    id: `client-${Math.random().toString(16).slice(2)}`,
+    ws: createSocket(sent),
+    msgTimestamps: [],
+    isAlive: true,
+    lastPong: Date.now(),
+  } as any;
+}
+
+function listen(server: Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function domainFixture() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const publicKeyPem = publicKey.export({ format: 'pem', type: 'spki' }).toString();
+
+  function signedDocument(baseUrl: string) {
+    const unsigned = {
+      schema: 'uruc.domain.document@v0',
+      domainId: 'domain.acme.social',
+      venue: {
+        moduleId: 'acme.social',
+        namespace: 'acme.social',
+      },
+      protocol: {
+        version: 'uruc-domain-v0',
+      },
+      publicKeys: [{
+        id: 'domain-key-1',
+        type: 'ed25519-pem',
+        publicKeyPem,
+      }],
+      endpoints: {
+        attachment: `${baseUrl}/uruc/attach`,
+        dispatch: `${baseUrl}/uruc/dispatch`,
+      },
+      capabilities: ['social.thread.write'],
+      hints: {},
+    };
+    return {
+      ...unsigned,
+      proof: {
+        type: 'ed25519-signature-2026',
+        verificationMethod: 'domain-key-1',
+        createdAt: '2026-05-03T00:00:00.000Z',
+        canonicalization: 'uruc-domain-document-v0-sorted-json-without-proof',
+        covered: [
+          'capabilities',
+          'domainId',
+          'endpoints',
+          'hints',
+          'protocol',
+          'publicKeys',
+          'schema',
+          'venue',
+        ],
+        signature: sign(null, canonicalDomainDocumentPayload(unsigned), privateKey).toString('base64'),
+      },
+    };
+  }
+
+  function signedReceipt(receipt: Record<string, unknown>) {
+    return {
+      ...receipt,
+      proof: {
+        type: 'ed25519-signature-2026',
+        verificationMethod: 'domain-key-1',
+        createdAt: '2026-05-03T00:00:01.000Z',
+        canonicalization: 'uruc-domain-dispatch-receipt-v0-sorted-json-without-proof',
+        signature: sign(null, canonicalDomainDispatchReceiptPayload(receipt), privateKey).toString('base64'),
+      },
+    };
+  }
+
+  return { publicKeyPem, signedDocument, signedReceipt };
+}
+
+describe('Domain signed dispatch', () => {
+  let db: ReturnType<typeof createDb>;
+  let auth: AuthService;
+  let permissions: PermissionCredentialService;
+  let hooks: HookRegistry;
+  let services: ServiceRegistry;
+  let gateway: WSGateway;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    auth = new AuthService(db);
+    permissions = new PermissionCredentialService(db);
+    hooks = new HookRegistry();
+    services = new ServiceRegistry();
+    services.register('permission', permissions);
+    gateway = new WSGateway({ port: 0 }, hooks, services, auth);
+  });
+
+  it('dispatches an attached domain venue request after City Core permission checks and records the signed receipt', async () => {
+    const fixture = domainFixture();
+    const receivedEnvelopes: Array<Record<string, any>> = [];
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(fixture.signedDocument(baseUrl)));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'accepted',
+          code: 'ATTACHED',
+          receiptId: 'attach-1',
+          validUntil: '2026-06-03T00:00:00.000Z',
+        }));
+        return;
+      }
+      if (req.url === '/uruc/dispatch' && req.method === 'POST') {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          const envelope = JSON.parse(body);
+          receivedEnvelopes.push(envelope);
+          expect(envelope).toMatchObject({
+            schema: DOMAIN_DISPATCH_ENVELOPE_SCHEMA,
+            city: { id: 'city.alpha' },
+            domain: { id: 'domain.acme.social' },
+            resident: { id: expect.any(String) },
+            venue: {
+              pluginId: 'acme.social',
+              moduleId: 'acme.social',
+              namespace: 'acme.social',
+            },
+            request: {
+              id: 'write-a',
+              command: 'acme.social.publish@v1',
+              type: 'acme.social.publish.request@v1',
+              payload: { text: 'hello' },
+            },
+            proofs: {
+              requiredCapabilities: ['social.thread.write'],
+              permissionCredentialRefs: [expect.stringMatching(/^perm_/)],
+            },
+          });
+          expect(verify(
+            null,
+            canonicalDomainDispatchEnvelopePayload(envelope),
+            createPublicKey(envelope.city.publicKeyPem),
+            Buffer.from(envelope.proof.signature, 'base64'),
+          )).toBe(true);
+          const receipt = {
+            schema: DOMAIN_DISPATCH_RECEIPT_SCHEMA,
+            status: 'delivered',
+            code: 'DOMAIN_DELIVERED',
+            receiptId: 'domain-receipt-1',
+            envelopeHash: envelope.envelopeHash,
+            eventRef: 'domain-event-1',
+          };
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify(fixture.signedReceipt(receipt)));
+        });
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const attachment = new DomainAttachmentService(db);
+      await attachment.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.social',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: { endpoint: baseUrl },
+          },
+        },
+      });
+
+      const domainDispatch = new DomainDispatchService(db, {
+        cityId: 'city.alpha',
+        pluginPlatform: {
+          listPlugins: () => [{
+            name: 'acme.social',
+            version: '1.0.0',
+            started: true,
+            state: 'active',
+            venue: {
+              moduleId: 'acme.social',
+              namespace: 'acme.social',
+              topology: {
+                declaration: 'domain_required',
+                mode: 'domain',
+                domain: { endpoint: baseUrl },
+              },
+            },
+          }],
+          getPluginDiagnostics: () => [],
+          listFrontendPlugins: async () => [],
+          readFrontendAsset: async () => null,
+        },
+        now: () => new Date('2026-05-03T00:00:00.000Z'),
+      });
+      services.register('domain-dispatch', domainDispatch);
+
+      const handler = vi.fn(async (ctx, msg) => {
+        ctx.gateway.send(ctx.ws, { id: msg.id, type: 'result', payload: { local: true } });
+      });
+      hooks.registerWSCommand('acme.social.publish@v1', handler, {
+        type: 'acme.social.publish@v1',
+        description: 'Publish to the shared social domain.',
+        pluginName: 'acme.social',
+        params: {},
+        controlPolicy: { controllerRequired: false },
+        protocol: {
+          subject: 'resident',
+          request: {
+            type: 'acme.social.publish.request@v1',
+            requiredCapabilities: ['social.thread.write'],
+          },
+          receipt: {
+            type: 'acme.social.publish.receipt@v1',
+            statuses: ['delivered', 'rejected'],
+          },
+          venue: {
+            id: 'acme.social',
+            moduleId: 'acme.social',
+          },
+        },
+      });
+
+      const user = await auth.register('domain-dispatch-user', 'domain-dispatch@example.com', 'secret-123');
+      const [shadow] = await auth.getAgentsByUser(user.id);
+      await permissions.approveCredential({
+        authorityUserId: user.id,
+        residentId: shadow.id,
+        capabilities: ['social.thread.write'],
+      });
+
+      const sent: SentEnvelope[] = [];
+      const client = createClient(sent);
+      (gateway as any).clients.set('client-a', client);
+      await (gateway as any).handleAgentAuth('client-a', client, {
+        id: 'auth-a',
+        type: 'auth',
+        payload: signToken(user.id, 'user'),
+      });
+
+      sent.length = 0;
+      await (gateway as any).handleMessage('client-a', {
+        id: 'write-a',
+        type: 'acme.social.publish@v1',
+        payload: { text: 'hello' },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(receivedEnvelopes).toHaveLength(1);
+      expect(sent.at(-1)).toMatchObject({
+        id: 'write-a',
+        type: 'result',
+        payload: {
+          ok: true,
+          code: 'DOMAIN_DELIVERED',
+          receiptId: 'domain-receipt-1',
+          eventRef: 'domain-event-1',
+        },
+      });
+      const audits = await db.select().from(schema.domainDispatchAudits);
+      expect(audits).toHaveLength(1);
+      expect(audits[0]).toMatchObject({
+        status: 'delivered',
+        cityId: 'city.alpha',
+        domainId: 'domain.acme.social',
+        residentId: shadow.id,
+        venueModuleId: 'acme.social',
+        venueNamespace: 'acme.social',
+        command: 'acme.social.publish@v1',
+        requestType: 'acme.social.publish.request@v1',
+        receiptCode: 'DOMAIN_DELIVERED',
+      });
+      expect(audits[0]?.envelopeHash).toMatch(/^[a-f0-9]{64}$/);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('keeps local topology on the local handler and does not create domain audit records', async () => {
+    const domainDispatch = new DomainDispatchService(db, {
+      cityId: 'city.alpha',
+      pluginPlatform: {
+        listPlugins: () => [{
+          name: 'acme.local',
+          version: '1.0.0',
+          started: true,
+          state: 'active',
+          venue: {
+            moduleId: 'acme.local',
+            namespace: 'acme.local',
+            topology: {
+              declaration: 'local',
+              mode: 'local',
+            },
+          },
+        }],
+        getPluginDiagnostics: () => [],
+        listFrontendPlugins: async () => [],
+        readFrontendAsset: async () => null,
+      },
+    });
+    services.register('domain-dispatch', domainDispatch);
+
+    const handler = vi.fn(async (ctx, msg) => {
+      ctx.gateway.send(ctx.ws, { id: msg.id, type: 'result', payload: { local: true } });
+    });
+    hooks.registerWSCommand('acme.local.echo@v1', handler, {
+      type: 'acme.local.echo@v1',
+      description: 'Local echo.',
+      pluginName: 'acme.local',
+      params: {},
+      controlPolicy: { controllerRequired: false },
+      protocol: {
+        subject: 'resident',
+        request: { type: 'acme.local.echo.request@v1' },
+        venue: { id: 'acme.local', moduleId: 'acme.local' },
+      },
+    });
+
+    const user = await auth.register('local-dispatch-user', 'local-dispatch@example.com', 'secret-123');
+    const sent: SentEnvelope[] = [];
+    const client = createClient(sent);
+    (gateway as any).clients.set('client-local', client);
+    await (gateway as any).handleAgentAuth('client-local', client, {
+      id: 'auth-local',
+      type: 'auth',
+      payload: signToken(user.id, 'user'),
+    });
+
+    sent.length = 0;
+    await (gateway as any).handleMessage('client-local', {
+      id: 'echo-a',
+      type: 'acme.local.echo@v1',
+      payload: { text: 'local' },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(sent.at(-1)).toMatchObject({
+      id: 'echo-a',
+      type: 'result',
+      payload: { local: true },
+    });
+    expect(await db.select().from(schema.domainDispatchAudits)).toHaveLength(0);
+  });
+
+  it('fails compactly for domain topology without an active attachment and does not call the local handler', async () => {
+    await db.insert(schema.domainAttachments).values({
+      id: 'failed-attachment-1',
+      status: 'failed',
+      domainId: 'domain.acme.unattached',
+      cityId: 'city.alpha',
+      pluginId: 'acme.unattached',
+      venueModuleId: 'acme.unattached',
+      venueNamespace: 'acme.unattached',
+      protocolVersion: 'uruc-domain-v0',
+      endpoint: 'https://domain.example/attach',
+      dispatchEndpoint: 'https://domain.example/dispatch',
+      documentUrl: 'https://domain.example/.well-known/uruc-domain.json',
+      documentHash: '0'.repeat(64),
+      publicKeys: '[]',
+      capabilities: '[]',
+      receiptCode: 'CITY_NOT_ALLOWED',
+      receipt: JSON.stringify({ ok: false, code: 'CITY_NOT_ALLOWED' }),
+      createdAt: new Date('2026-05-03T00:00:00.000Z'),
+      updatedAt: new Date('2026-05-03T00:00:00.000Z'),
+    });
+
+    const domainDispatch = new DomainDispatchService(db, {
+      cityId: 'city.alpha',
+      pluginPlatform: {
+        listPlugins: () => [{
+          name: 'acme.unattached',
+          version: '1.0.0',
+          started: true,
+          state: 'active',
+          venue: {
+            moduleId: 'acme.unattached',
+            namespace: 'acme.unattached',
+            topology: {
+              declaration: 'domain_required',
+              mode: 'domain',
+              domain: { endpoint: 'https://domain.example' },
+            },
+          },
+        }],
+        getPluginDiagnostics: () => [],
+        listFrontendPlugins: async () => [],
+        readFrontendAsset: async () => null,
+      },
+    });
+    services.register('domain-dispatch', domainDispatch);
+
+    const handler = vi.fn(async (ctx, msg) => {
+      ctx.gateway.send(ctx.ws, { id: msg.id, type: 'result', payload: { local: true } });
+    });
+    hooks.registerWSCommand('acme.unattached.write@v1', handler, {
+      type: 'acme.unattached.write@v1',
+      description: 'Domain write.',
+      pluginName: 'acme.unattached',
+      params: {},
+      controlPolicy: { controllerRequired: false },
+      protocol: {
+        subject: 'resident',
+        request: { type: 'acme.unattached.write.request@v1' },
+        venue: { id: 'acme.unattached', moduleId: 'acme.unattached' },
+      },
+    });
+
+    const user = await auth.register('unattached-domain-user', 'unattached-domain@example.com', 'secret-123');
+    const sent: SentEnvelope[] = [];
+    const client = createClient(sent);
+    (gateway as any).clients.set('client-unattached', client);
+    await (gateway as any).handleAgentAuth('client-unattached', client, {
+      id: 'auth-unattached',
+      type: 'auth',
+      payload: signToken(user.id, 'user'),
+    });
+
+    sent.length = 0;
+    await (gateway as any).handleMessage('client-unattached', {
+      id: 'write-unattached',
+      type: 'acme.unattached.write@v1',
+      payload: {},
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(sent.at(-1)).toMatchObject({
+      id: 'write-unattached',
+      type: 'error',
+      payload: {
+        ok: false,
+        code: 'DOMAIN_ATTACHMENT_NOT_ACTIVE',
+        cityId: 'city.alpha',
+        venueModuleId: 'acme.unattached',
+      },
+    });
+    expect(await db.select().from(schema.domainDispatchAudits)).toHaveLength(0);
+  });
+
+  it('records a failed audit receipt when attached domain dispatch returns a non-JSON receipt', async () => {
+    const fixture = domainFixture();
+    let baseUrl = '';
+    const server = createServer((req, res) => {
+      if (req.url === '/.well-known/uruc-domain.json') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(fixture.signedDocument(baseUrl)));
+        return;
+      }
+      if (req.url === '/uruc/attach' && req.method === 'POST') {
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          schema: 'uruc.domain.attachment.receipt@v0',
+          status: 'accepted',
+          code: 'ATTACHED',
+          receiptId: 'attach-failure',
+          validUntil: '2026-06-03T00:00:00.000Z',
+        }));
+        return;
+      }
+      if (req.url === '/uruc/dispatch' && req.method === 'POST') {
+        res.statusCode = 502;
+        res.setHeader('content-type', 'text/plain');
+        res.end('bad gateway');
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    baseUrl = await listen(server);
+
+    try {
+      const attachment = new DomainAttachmentService(db);
+      await attachment.attachVenueDomain({
+        cityId: 'city.alpha',
+        pluginId: 'acme.failure',
+        venue: {
+          moduleId: 'acme.social',
+          namespace: 'acme.social',
+          topology: {
+            declaration: 'domain_required',
+            mode: 'domain',
+            domain: { endpoint: baseUrl },
+          },
+        },
+      });
+
+      const domainDispatch = new DomainDispatchService(db, {
+        cityId: 'city.alpha',
+        pluginPlatform: {
+          listPlugins: () => [{
+            name: 'acme.failure',
+            version: '1.0.0',
+            started: true,
+            state: 'active',
+            venue: {
+              moduleId: 'acme.social',
+              namespace: 'acme.social',
+              topology: {
+                declaration: 'domain_required',
+                mode: 'domain',
+                domain: { endpoint: baseUrl },
+              },
+            },
+          }],
+          getPluginDiagnostics: () => [],
+          listFrontendPlugins: async () => [],
+          readFrontendAsset: async () => null,
+        },
+        now: () => new Date('2026-05-03T00:00:00.000Z'),
+      });
+      services.register('domain-dispatch', domainDispatch);
+
+      const handler = vi.fn(async (ctx, msg) => {
+        ctx.gateway.send(ctx.ws, { id: msg.id, type: 'result', payload: { local: true } });
+      });
+      hooks.registerWSCommand('acme.failure.write@v1', handler, {
+        type: 'acme.failure.write@v1',
+        description: 'Domain write.',
+        pluginName: 'acme.failure',
+        params: {},
+        controlPolicy: { controllerRequired: false },
+        protocol: {
+          subject: 'resident',
+          request: { type: 'acme.failure.write.request@v1' },
+          venue: { id: 'acme.social', moduleId: 'acme.social' },
+        },
+      });
+
+      const user = await auth.register('domain-failure-user', 'domain-failure@example.com', 'secret-123');
+      const sent: SentEnvelope[] = [];
+      const client = createClient(sent);
+      (gateway as any).clients.set('client-failure', client);
+      await (gateway as any).handleAgentAuth('client-failure', client, {
+        id: 'auth-failure',
+        type: 'auth',
+        payload: signToken(user.id, 'user'),
+      });
+
+      sent.length = 0;
+      await (gateway as any).handleMessage('client-failure', {
+        id: 'write-failure',
+        type: 'acme.failure.write@v1',
+        payload: { text: 'fail' },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(sent.at(-1)).toMatchObject({
+        id: 'write-failure',
+        type: 'error',
+        payload: {
+          ok: false,
+          code: 'DOMAIN_DISPATCH_RECEIPT_CONTENT_TYPE_INVALID',
+          cityId: 'city.alpha',
+          domainId: 'domain.acme.social',
+          venueModuleId: 'acme.social',
+        },
+      });
+      const audits = await db.select().from(schema.domainDispatchAudits);
+      expect(audits).toHaveLength(1);
+      expect(audits[0]).toMatchObject({
+        status: 'failed',
+        receiptCode: 'DOMAIN_DISPATCH_RECEIPT_CONTENT_TYPE_INVALID',
+      });
+    } finally {
+      await close(server);
+    }
+  });
+});

--- a/packages/server/src/core/domain/dispatch.ts
+++ b/packages/server/src/core/domain/dispatch.ts
@@ -1,0 +1,492 @@
+import { createHash, createPublicKey, generateKeyPairSync, randomUUID, sign, verify } from 'crypto';
+import { and, desc, eq } from 'drizzle-orm';
+
+import { type UrucDb, schema } from '../database/index.js';
+import type { CommandSchema, WSMessage } from '../plugin-system/hook-registry.js';
+import type { AgentSession } from '../../types/index.js';
+import type { PermissionCredential } from '../permission/service.js';
+import type { PluginPlatformHealthProvider } from '../plugin-platform/types.js';
+import { DomainDocumentError } from './document.js';
+
+export const DOMAIN_DISPATCH_ENVELOPE_SCHEMA = 'uruc.domain.dispatch.envelope@v0';
+export const DOMAIN_DISPATCH_RECEIPT_SCHEMA = 'uruc.domain.dispatch.receipt@v0';
+export const DOMAIN_DISPATCH_ENVELOPE_CANONICALIZATION = 'uruc-domain-dispatch-envelope-v0-sorted-json-without-proof';
+export const DOMAIN_DISPATCH_RECEIPT_CANONICALIZATION = 'uruc-domain-dispatch-receipt-v0-sorted-json-without-proof';
+
+type FetchLike = typeof fetch;
+
+export interface DomainDispatchServiceOptions {
+  cityId: string;
+  cityKeyId?: string;
+  privateKeyPem?: string;
+  publicKeyPem?: string;
+  fetch?: FetchLike;
+  timeoutMs?: number;
+  maxReceiptBytes?: number;
+  now?: () => Date;
+  nonce?: () => string;
+  pluginPlatform?: PluginPlatformHealthProvider;
+}
+
+export interface DomainDispatchInput {
+  schema: CommandSchema;
+  msg: WSMessage;
+  session: AgentSession;
+  permissionCredentials: PermissionCredential[];
+}
+
+export interface DomainDispatchCompactReceipt {
+  ok: boolean;
+  code: string;
+  receiptId?: string;
+  eventRef?: string;
+  auditId?: string;
+  domainId?: string;
+  cityId: string;
+  venueModuleId: string;
+}
+
+export type DomainDispatchResult =
+  | { status: 'skipped' }
+  | {
+    status: 'delivered' | 'failed';
+    receipt: DomainDispatchCompactReceipt;
+  };
+
+declare module '../plugin-system/service-registry.js' {
+  interface ServiceMap {
+    'domain-dispatch': DomainDispatchService;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, stableValue(value[key])]),
+  );
+}
+
+export function canonicalDomainDispatchEnvelopePayload(envelope: Record<string, unknown>): Buffer {
+  const { proof: _proof, envelopeHash: _envelopeHash, ...payload } = envelope;
+  return Buffer.from(JSON.stringify(stableValue(payload)), 'utf8');
+}
+
+export function canonicalDomainDispatchReceiptPayload(receipt: Record<string, unknown>): Buffer {
+  const { proof: _proof, ...payload } = receipt;
+  return Buffer.from(JSON.stringify(stableValue(payload)), 'utf8');
+}
+
+async function readLimitedText(response: Response, maxBytes: number): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      throw new DomainDocumentError('DOMAIN_RESPONSE_TOO_LARGE', 'Domain response is too large');
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function requireJsonContentType(response: Response, code: string): void {
+  const mediaType = (response.headers.get('content-type') ?? '').toLowerCase().split(';', 1)[0].trim();
+  if (mediaType !== 'application/json' && !mediaType.endsWith('+json')) {
+    throw new DomainDocumentError(code, 'Domain response content-type is not JSON');
+  }
+}
+
+function parseJson(text: string, code: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new DomainDocumentError(code, 'Domain response is not valid JSON');
+  }
+}
+
+function parsePublicKeys(raw: string): Array<{ id: string; type: 'ed25519-pem'; publicKeyPem: string }> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((key): key is { id: string; type: 'ed25519-pem'; publicKeyPem: string } => (
+      isRecord(key)
+      && typeof key.id === 'string'
+      && key.type === 'ed25519-pem'
+      && typeof key.publicKeyPem === 'string'
+    ));
+  } catch {
+    return [];
+  }
+}
+
+function hashPayload(payload: Buffer): string {
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function compactReceipt(input: {
+  ok: boolean;
+  code: string;
+  cityId: string;
+  venueModuleId: string;
+  domainId?: string;
+  auditId?: string;
+  receiptId?: string;
+  eventRef?: string;
+}): DomainDispatchCompactReceipt {
+  return {
+    ok: input.ok,
+    code: input.code,
+    cityId: input.cityId,
+    venueModuleId: input.venueModuleId,
+    ...(input.domainId ? { domainId: input.domainId } : {}),
+    ...(input.auditId ? { auditId: input.auditId } : {}),
+    ...(input.receiptId ? { receiptId: input.receiptId } : {}),
+    ...(input.eventRef ? { eventRef: input.eventRef } : {}),
+  };
+}
+
+export class DomainDispatchService {
+  private readonly cityId: string;
+  private readonly cityKeyId: string;
+  private readonly privateKeyPem: string;
+  private readonly publicKeyPem: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  private readonly maxReceiptBytes: number;
+  private readonly now: () => Date;
+  private readonly nonce: () => string;
+  private readonly pluginPlatform?: PluginPlatformHealthProvider;
+
+  constructor(
+    private readonly db: UrucDb,
+    options: DomainDispatchServiceOptions,
+  ) {
+    const keyPair = options.privateKeyPem && options.publicKeyPem
+      ? null
+      : generateKeyPairSync('ed25519');
+    this.cityId = options.cityId;
+    this.cityKeyId = options.cityKeyId ?? 'city-dispatch-key-1';
+    this.privateKeyPem = options.privateKeyPem
+      ?? keyPair!.privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+    this.publicKeyPem = options.publicKeyPem
+      ?? keyPair!.publicKey.export({ format: 'pem', type: 'spki' }).toString();
+    this.fetchImpl = options.fetch ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? 3_000;
+    this.maxReceiptBytes = options.maxReceiptBytes ?? 32 * 1024;
+    this.now = options.now ?? (() => new Date());
+    this.nonce = options.nonce ?? (() => randomUUID());
+    this.pluginPlatform = options.pluginPlatform;
+  }
+
+  async dispatchVenueRequest(input: DomainDispatchInput): Promise<DomainDispatchResult> {
+    const pluginId = input.schema.pluginName;
+    if (!pluginId || pluginId === 'core') return { status: 'skipped' };
+
+    const plugin = this.pluginPlatform?.listPlugins().find((item) => item.name === pluginId);
+    if (plugin?.venue?.topology?.mode && plugin.venue.topology.mode !== 'domain') {
+      return { status: 'skipped' };
+    }
+
+    const venueModuleId = input.schema.protocol?.venue?.moduleId ?? plugin?.venue?.moduleId ?? pluginId;
+    const venueNamespace = plugin?.venue?.namespace ?? input.schema.protocol?.venue?.id ?? venueModuleId;
+    const attachment = await this.findActiveAttachment(pluginId, venueModuleId);
+    if (!attachment) {
+      return plugin?.venue?.topology?.mode === 'domain'
+        ? {
+          status: 'failed',
+          receipt: compactReceipt({
+            ok: false,
+            code: 'DOMAIN_ATTACHMENT_NOT_ACTIVE',
+            cityId: this.cityId,
+            venueModuleId,
+          }),
+        }
+        : { status: 'skipped' };
+    }
+    if (!attachment.dispatchEndpoint) {
+      return {
+        status: 'failed',
+        receipt: compactReceipt({
+          ok: false,
+          code: 'DOMAIN_DISPATCH_ENDPOINT_MISSING',
+          cityId: this.cityId,
+          venueModuleId,
+          domainId: attachment.domainId,
+        }),
+      };
+    }
+
+    const requestType = input.schema.protocol?.request?.type ?? input.msg.type;
+    const requiredCapabilities = input.schema.protocol?.request?.requiredCapabilities ?? [];
+    const envelopeBase = {
+      schema: DOMAIN_DISPATCH_ENVELOPE_SCHEMA,
+      city: {
+        id: this.cityId,
+        keyId: this.cityKeyId,
+        publicKeyPem: this.publicKeyPem,
+      },
+      domain: {
+        id: attachment.domainId,
+      },
+      attachment: {
+        id: attachment.id,
+      },
+      resident: {
+        id: input.session.agentId,
+      },
+      venue: {
+        pluginId,
+        moduleId: attachment.venueModuleId,
+        namespace: attachment.venueNamespace || venueNamespace,
+      },
+      request: {
+        id: input.msg.id,
+        command: input.msg.type,
+        type: requestType,
+        payload: input.msg.payload ?? null,
+      },
+      proofs: {
+        requiredCapabilities,
+        permissionCredentialRefs: input.permissionCredentials
+          .filter((credential) => requiredCapabilities.some((capability) => credential.capabilities.includes(capability)))
+          .map((credential) => credential.id)
+          .sort(),
+      },
+      issuedAt: this.now().toISOString(),
+      nonce: this.nonce(),
+    };
+    const envelopeHash = hashPayload(canonicalDomainDispatchEnvelopePayload(envelopeBase));
+    const envelope = {
+      ...envelopeBase,
+      envelopeHash,
+      proof: {
+        type: 'ed25519-signature-2026',
+        verificationMethod: this.cityKeyId,
+        canonicalization: DOMAIN_DISPATCH_ENVELOPE_CANONICALIZATION,
+        signature: sign(null, canonicalDomainDispatchEnvelopePayload(envelopeBase), this.privateKeyPem).toString('base64'),
+      },
+    };
+
+    const auditId = await this.insertAudit({
+      attachmentId: attachment.id,
+      cityId: this.cityId,
+      domainId: attachment.domainId,
+      residentId: input.session.agentId,
+      pluginId,
+      venueModuleId: attachment.venueModuleId,
+      venueNamespace: attachment.venueNamespace,
+      command: input.msg.type,
+      requestType,
+      endpoint: attachment.dispatchEndpoint,
+      envelopeHash,
+      envelope,
+    });
+
+    try {
+      const response = await this.fetchWithTimeout(attachment.dispatchEndpoint, {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(envelope),
+      });
+      requireJsonContentType(response, 'DOMAIN_DISPATCH_RECEIPT_CONTENT_TYPE_INVALID');
+      const receipt = this.parseDispatchReceipt(
+        parseJson(await readLimitedText(response, this.maxReceiptBytes), 'DOMAIN_DISPATCH_RECEIPT_JSON_INVALID'),
+        attachment,
+        envelopeHash,
+      );
+      const delivered = response.ok && (receipt.status === 'accepted' || receipt.status === 'delivered');
+      const result = compactReceipt({
+        ok: delivered,
+        code: receipt.code,
+        cityId: this.cityId,
+        venueModuleId: attachment.venueModuleId,
+        domainId: attachment.domainId,
+        auditId,
+        receiptId: receipt.receiptId,
+        eventRef: receipt.eventRef,
+      });
+      await this.updateAudit(auditId, {
+        status: delivered ? 'delivered' : 'failed',
+        receiptCode: receipt.code,
+        receipt: result,
+      });
+      return {
+        status: delivered ? 'delivered' : 'failed',
+        receipt: result,
+      };
+    } catch (error) {
+      const code = error instanceof DomainDocumentError ? error.code : 'DOMAIN_DISPATCH_FAILED';
+      const result = compactReceipt({
+        ok: false,
+        code,
+        cityId: this.cityId,
+        venueModuleId: attachment.venueModuleId,
+        domainId: attachment.domainId,
+        auditId,
+      });
+      await this.updateAudit(auditId, {
+        status: 'failed',
+        receiptCode: code,
+        receipt: result,
+      });
+      return { status: 'failed', receipt: result };
+    }
+  }
+
+  private async findActiveAttachment(pluginId: string, venueModuleId: string) {
+    const rows = await this.db.select()
+      .from(schema.domainAttachments)
+      .where(and(
+        eq(schema.domainAttachments.pluginId, pluginId),
+        eq(schema.domainAttachments.venueModuleId, venueModuleId),
+        eq(schema.domainAttachments.status, 'attached'),
+      ))
+      .orderBy(desc(schema.domainAttachments.updatedAt));
+    const now = this.now().getTime();
+    return rows.find((row) => !row.validUntil || row.validUntil.getTime() > now);
+  }
+
+  private parseDispatchReceipt(
+    raw: unknown,
+    attachment: typeof schema.domainAttachments.$inferSelect,
+    envelopeHash: string,
+  ): {
+    status: 'accepted' | 'rejected' | 'delivered' | 'failed';
+    code: string;
+    receiptId?: string;
+    eventRef?: string;
+  } {
+    if (!isRecord(raw)) throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt');
+    if (raw.schema !== DOMAIN_DISPATCH_RECEIPT_SCHEMA) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt schema');
+    }
+    if (raw.status !== 'accepted' && raw.status !== 'rejected' && raw.status !== 'delivered' && raw.status !== 'failed') {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt status');
+    }
+    if (typeof raw.code !== 'string' || raw.code.trim() === '') {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt code');
+    }
+    if (raw.envelopeHash !== envelopeHash) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_HASH_MISMATCH', 'Dispatch receipt envelope hash mismatch');
+    }
+    const proof = raw.proof;
+    if (!isRecord(proof)
+      || proof.type !== 'ed25519-signature-2026'
+      || proof.canonicalization !== DOMAIN_DISPATCH_RECEIPT_CANONICALIZATION
+      || typeof proof.verificationMethod !== 'string'
+      || typeof proof.signature !== 'string') {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_PROOF_INVALID', 'Invalid dispatch receipt proof');
+    }
+    const verificationKey = parsePublicKeys(attachment.publicKeys).find((key) => key.id === proof.verificationMethod);
+    if (!verificationKey) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_PROOF_INVALID', 'Dispatch receipt proof key not found');
+    }
+    let valid = false;
+    try {
+      valid = verify(
+        null,
+        canonicalDomainDispatchReceiptPayload(raw),
+        createPublicKey(verificationKey.publicKeyPem),
+        Buffer.from(proof.signature, 'base64'),
+      );
+    } catch {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_PROOF_INVALID', 'Dispatch receipt proof cannot be verified');
+    }
+    if (!valid) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_SIGNATURE_INVALID', 'Dispatch receipt signature invalid');
+    }
+    return {
+      status: raw.status,
+      code: raw.code,
+      ...(typeof raw.receiptId === 'string' ? { receiptId: raw.receiptId } : {}),
+      ...(typeof raw.eventRef === 'string' ? { eventRef: raw.eventRef } : {}),
+    };
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, {
+        ...init,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new DomainDocumentError('DOMAIN_REQUEST_TIMEOUT', 'Domain request timed out');
+      }
+      throw new DomainDocumentError('DOMAIN_DISPATCH_FAILED', 'Domain dispatch failed');
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async insertAudit(input: {
+    attachmentId: string;
+    cityId: string;
+    domainId: string;
+    residentId: string;
+    pluginId: string;
+    venueModuleId: string;
+    venueNamespace: string;
+    command: string;
+    requestType: string;
+    endpoint: string;
+    envelopeHash: string;
+    envelope: unknown;
+  }): Promise<string> {
+    const id = randomUUID();
+    const now = this.now();
+    await this.db.insert(schema.domainDispatchAudits).values({
+      id,
+      status: 'pending',
+      attachmentId: input.attachmentId,
+      cityId: input.cityId,
+      domainId: input.domainId,
+      residentId: input.residentId,
+      pluginId: input.pluginId,
+      venueModuleId: input.venueModuleId,
+      venueNamespace: input.venueNamespace,
+      command: input.command,
+      requestType: input.requestType,
+      endpoint: input.endpoint,
+      envelopeHash: input.envelopeHash,
+      envelope: JSON.stringify(input.envelope),
+      receiptCode: 'PENDING',
+      receipt: JSON.stringify({ ok: false, code: 'PENDING' }),
+      createdAt: now,
+      updatedAt: now,
+    });
+    return id;
+  }
+
+  private async updateAudit(id: string, input: {
+    status: 'delivered' | 'failed';
+    receiptCode: string;
+    receipt: unknown;
+  }): Promise<void> {
+    await this.db.update(schema.domainDispatchAudits)
+      .set({
+        status: input.status,
+        receiptCode: input.receiptCode,
+        receipt: JSON.stringify(input.receipt),
+        updatedAt: this.now(),
+      })
+      .where(eq(schema.domainDispatchAudits.id, id));
+  }
+}

--- a/packages/server/src/core/domain/dispatch.ts
+++ b/packages/server/src/core/domain/dispatch.ts
@@ -12,6 +12,32 @@ export const DOMAIN_DISPATCH_ENVELOPE_SCHEMA = 'uruc.domain.dispatch.envelope@v0
 export const DOMAIN_DISPATCH_RECEIPT_SCHEMA = 'uruc.domain.dispatch.receipt@v0';
 export const DOMAIN_DISPATCH_ENVELOPE_CANONICALIZATION = 'uruc-domain-dispatch-envelope-v0-sorted-json-without-proof';
 export const DOMAIN_DISPATCH_RECEIPT_CANONICALIZATION = 'uruc-domain-dispatch-receipt-v0-sorted-json-without-proof';
+export const DOMAIN_DISPATCH_ENVELOPE_SIGNED_FIELDS = [
+  'attachment',
+  'audit',
+  'city',
+  'domain',
+  'issuedAt',
+  'nonce',
+  'proofs',
+  'request',
+  'resident',
+  'schema',
+  'venue',
+] as const;
+export const DOMAIN_DISPATCH_RECEIPT_SIGNED_FIELDS = [
+  'auditId',
+  'cityId',
+  'code',
+  'domainId',
+  'envelopeHash',
+  'eventRef',
+  'issuedAt',
+  'receiptId',
+  'requestId',
+  'schema',
+  'status',
+] as const;
 
 type FetchLike = typeof fetch;
 
@@ -135,6 +161,32 @@ function hashPayload(payload: Buffer): string {
   return createHash('sha256').update(payload).digest('hex');
 }
 
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function requireExactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  code: string,
+  label: string,
+): void {
+  const extra = Object.keys(value).filter((key) => !allowed.includes(key));
+  const missing = allowed.filter((key) => !(key in value));
+  if (extra.length > 0 || missing.length > 0) {
+    throw new DomainDocumentError(code, `Invalid dispatch ${label}`);
+  }
+}
+
+function requireIsoTimestamp(value: unknown, code: string, label: string): string {
+  const text = stringValue(value);
+  const time = text ? Date.parse(text) : Number.NaN;
+  if (!text || Number.isNaN(time) || new Date(time).toISOString() !== text) {
+    throw new DomainDocumentError(code, `Invalid dispatch ${label}`);
+  }
+  return text;
+}
+
 function compactReceipt(input: {
   ok: boolean;
   code: string;
@@ -190,12 +242,19 @@ export class DomainDispatchService {
     this.pluginPlatform = options.pluginPlatform;
   }
 
+  isDomainVenueRequest(schema: CommandSchema): boolean {
+    const pluginId = schema.pluginName;
+    if (!pluginId || pluginId === 'core') return false;
+    const plugin = this.pluginPlatform?.listPlugins().find((item) => item.name === pluginId);
+    return plugin?.venue?.topology?.mode === 'domain';
+  }
+
   async dispatchVenueRequest(input: DomainDispatchInput): Promise<DomainDispatchResult> {
     const pluginId = input.schema.pluginName;
     if (!pluginId || pluginId === 'core') return { status: 'skipped' };
 
     const plugin = this.pluginPlatform?.listPlugins().find((item) => item.name === pluginId);
-    if (plugin?.venue?.topology?.mode && plugin.venue.topology.mode !== 'domain') {
+    if (plugin?.venue?.topology?.mode !== 'domain') {
       return { status: 'skipped' };
     }
 
@@ -230,8 +289,12 @@ export class DomainDispatchService {
 
     const requestType = input.schema.protocol?.request?.type ?? input.msg.type;
     const requiredCapabilities = input.schema.protocol?.request?.requiredCapabilities ?? [];
+    const auditId = randomUUID();
     const envelopeBase = {
       schema: DOMAIN_DISPATCH_ENVELOPE_SCHEMA,
+      audit: {
+        id: auditId,
+      },
       city: {
         id: this.cityId,
         keyId: this.cityKeyId,
@@ -242,6 +305,8 @@ export class DomainDispatchService {
       },
       attachment: {
         id: attachment.id,
+        documentUrl: attachment.documentUrl,
+        documentHash: attachment.documentHash,
       },
       resident: {
         id: input.session.agentId,
@@ -275,11 +340,13 @@ export class DomainDispatchService {
         type: 'ed25519-signature-2026',
         verificationMethod: this.cityKeyId,
         canonicalization: DOMAIN_DISPATCH_ENVELOPE_CANONICALIZATION,
+        covered: [...DOMAIN_DISPATCH_ENVELOPE_SIGNED_FIELDS],
         signature: sign(null, canonicalDomainDispatchEnvelopePayload(envelopeBase), this.privateKeyPem).toString('base64'),
       },
     };
 
-    const auditId = await this.insertAudit({
+    await this.insertAudit({
+      id: auditId,
       attachmentId: attachment.id,
       cityId: this.cityId,
       domainId: attachment.domainId,
@@ -308,6 +375,8 @@ export class DomainDispatchService {
         parseJson(await readLimitedText(response, this.maxReceiptBytes), 'DOMAIN_DISPATCH_RECEIPT_JSON_INVALID'),
         attachment,
         envelopeHash,
+        auditId,
+        input.msg.id,
       );
       const delivered = response.ok && (receipt.status === 'accepted' || receipt.status === 'delivered');
       const result = compactReceipt({
@@ -365,31 +434,63 @@ export class DomainDispatchService {
     raw: unknown,
     attachment: typeof schema.domainAttachments.$inferSelect,
     envelopeHash: string,
+    auditId: string,
+    requestId: string,
   ): {
     status: 'accepted' | 'rejected' | 'delivered' | 'failed';
     code: string;
-    receiptId?: string;
+    receiptId: string;
     eventRef?: string;
   } {
     if (!isRecord(raw)) throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt');
+    requireExactKeys(
+      raw,
+      [...DOMAIN_DISPATCH_RECEIPT_SIGNED_FIELDS, 'proof'],
+      'DOMAIN_DISPATCH_RECEIPT_INVALID',
+      'receipt fields',
+    );
     if (raw.schema !== DOMAIN_DISPATCH_RECEIPT_SCHEMA) {
       throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt schema');
+    }
+    if (raw.domainId !== attachment.domainId) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_DOMAIN_MISMATCH', 'Dispatch receipt domain mismatch');
+    }
+    if (raw.cityId !== this.cityId) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_CITY_MISMATCH', 'Dispatch receipt city mismatch');
+    }
+    if (raw.auditId !== auditId) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_AUDIT_MISMATCH', 'Dispatch receipt audit mismatch');
+    }
+    if (raw.requestId !== requestId) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_REQUEST_MISMATCH', 'Dispatch receipt request mismatch');
     }
     if (raw.status !== 'accepted' && raw.status !== 'rejected' && raw.status !== 'delivered' && raw.status !== 'failed') {
       throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt status');
     }
-    if (typeof raw.code !== 'string' || raw.code.trim() === '') {
+    const code = stringValue(raw.code);
+    if (!code) {
       throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt code');
     }
+    const receiptId = stringValue(raw.receiptId);
+    if (!receiptId) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt id');
+    }
+    const eventRef = raw.eventRef === null ? undefined : stringValue(raw.eventRef);
+    if (raw.eventRef !== null && !eventRef) {
+      throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_INVALID', 'Invalid dispatch receipt eventRef');
+    }
+    requireIsoTimestamp(raw.issuedAt, 'DOMAIN_DISPATCH_RECEIPT_INVALID', 'receipt issuedAt');
     if (raw.envelopeHash !== envelopeHash) {
       throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_HASH_MISMATCH', 'Dispatch receipt envelope hash mismatch');
     }
     const proof = raw.proof;
+    const covered = isRecord(proof) && Array.isArray(proof.covered) ? proof.covered : undefined;
     if (!isRecord(proof)
       || proof.type !== 'ed25519-signature-2026'
       || proof.canonicalization !== DOMAIN_DISPATCH_RECEIPT_CANONICALIZATION
       || typeof proof.verificationMethod !== 'string'
-      || typeof proof.signature !== 'string') {
+      || typeof proof.signature !== 'string'
+      || JSON.stringify(covered) !== JSON.stringify(DOMAIN_DISPATCH_RECEIPT_SIGNED_FIELDS)) {
       throw new DomainDocumentError('DOMAIN_DISPATCH_RECEIPT_PROOF_INVALID', 'Invalid dispatch receipt proof');
     }
     const verificationKey = parsePublicKeys(attachment.publicKeys).find((key) => key.id === proof.verificationMethod);
@@ -412,9 +513,9 @@ export class DomainDispatchService {
     }
     return {
       status: raw.status,
-      code: raw.code,
-      ...(typeof raw.receiptId === 'string' ? { receiptId: raw.receiptId } : {}),
-      ...(typeof raw.eventRef === 'string' ? { eventRef: raw.eventRef } : {}),
+      code,
+      receiptId,
+      ...(eventRef ? { eventRef } : {}),
     };
   }
 
@@ -437,6 +538,7 @@ export class DomainDispatchService {
   }
 
   private async insertAudit(input: {
+    id: string;
     attachmentId: string;
     cityId: string;
     domainId: string;
@@ -449,11 +551,10 @@ export class DomainDispatchService {
     endpoint: string;
     envelopeHash: string;
     envelope: unknown;
-  }): Promise<string> {
-    const id = randomUUID();
+  }): Promise<void> {
     const now = this.now();
     await this.db.insert(schema.domainDispatchAudits).values({
-      id,
+      id: input.id,
       status: 'pending',
       attachmentId: input.attachmentId,
       cityId: input.cityId,
@@ -472,7 +573,6 @@ export class DomainDispatchService {
       createdAt: now,
       updatedAt: now,
     });
-    return id;
   }
 
   private async updateAudit(id: string, input: {

--- a/packages/server/src/core/domain/document.ts
+++ b/packages/server/src/core/domain/document.ts
@@ -31,6 +31,7 @@ export interface DomainDocument {
   }>;
   endpoints: {
     attachment: string;
+    dispatch?: string;
   };
   capabilities: string[];
   hints?: Record<string, unknown>;
@@ -141,7 +142,7 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
   if (!isRecord(proof)) throw new DomainDocumentError('DOMAIN_DOCUMENT_PROOF_INVALID', 'Invalid Domain Document proof');
   requireExactKeys(venue, ['moduleId', 'namespace'], 'DOMAIN_DOCUMENT_VENUE_INVALID', 'venue fields');
   requireExactKeys(protocol, ['version'], 'DOMAIN_DOCUMENT_PROTOCOL_INVALID', 'protocol fields');
-  requireExactKeys(endpoints, ['attachment'], 'DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'endpoint fields');
+  requireExactKeys(endpoints, ['attachment', 'dispatch'], 'DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'endpoint fields');
   requireExactKeys(proof, ['type', 'verificationMethod', 'createdAt', 'canonicalization', 'covered', 'signature'], 'DOMAIN_DOCUMENT_PROOF_INVALID', 'proof fields');
 
   const publicKeysValue = raw.publicKeys;
@@ -193,6 +194,9 @@ function parseDomainDocumentShape(raw: unknown): DomainDocument {
     publicKeys,
     endpoints: {
       attachment: requireUrl(endpoints.attachment, 'DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'endpoints.attachment'),
+      ...(endpoints.dispatch !== undefined
+        ? { dispatch: requireUrl(endpoints.dispatch, 'DOMAIN_DOCUMENT_ENDPOINT_INVALID', 'endpoints.dispatch') }
+        : {}),
     },
     capabilities: requireStringArray(raw.capabilities, 'DOMAIN_DOCUMENT_CAPABILITIES_INVALID', 'capabilities'),
     ...(hints ? { hints } : {}),

--- a/packages/server/src/core/domain/index.ts
+++ b/packages/server/src/core/domain/index.ts
@@ -1,2 +1,3 @@
 export * from './document.js';
+export * from './dispatch.js';
 export * from './service.js';

--- a/packages/server/src/core/domain/service.ts
+++ b/packages/server/src/core/domain/service.ts
@@ -336,10 +336,12 @@ export class DomainAttachmentService {
       venueNamespace: input.input.venue.namespace,
       protocolVersion: input.document.protocol.version,
       endpoint: input.document.endpoints.attachment,
+      dispatchEndpoint: input.document.endpoints.dispatch ?? null,
       documentUrl: input.documentUrl,
       documentHash: createHash('sha256')
         .update(canonicalDomainDocumentPayload(input.document as unknown as Record<string, unknown>))
         .digest('hex'),
+      publicKeys: JSON.stringify(input.document.publicKeys),
       capabilities: JSON.stringify(input.capabilities),
       receiptCode: input.receiptCode,
       receipt: JSON.stringify(input.receipt),

--- a/packages/server/src/core/server/ws-gateway.ts
+++ b/packages/server/src/core/server/ws-gateway.ts
@@ -16,7 +16,7 @@ import type { IncomingMessage } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { nanoid } from 'nanoid';
 
-import type { CommandSchema, HookRegistry, WSContext, WSGatewayPublic, WSDispatchResult } from '../plugin-system/hook-registry.js';
+import type { CommandSchema, HookRegistry, WSCommandHookContext, WSContext, WSGatewayPublic, WSDispatchResult } from '../plugin-system/hook-registry.js';
 import type { ServiceRegistry } from '../plugin-system/service-registry.js';
 import type { AuthService } from '../auth/service.js';
 import type { PermissionCredential } from '../permission/service.js';
@@ -336,6 +336,11 @@ export class WSGateway implements WSGatewayPublic {
       if (!canExecute) return;
       permissionCredentials = canExecute.credentials;
 
+      const domainDispatchService = this.services.tryGet('domain-dispatch');
+      if (domainDispatchService?.isDomainVenueRequest(schema)) {
+        const policyAllowed = await this.canPassRuntimePolicies(clientId, client, schema, msg);
+        if (!policyAllowed) return;
+      }
       const domainDispatch = await this.dispatchDomainVenueRequest(client, schema, msg, permissionCredentials);
       if (domainDispatch !== 'skipped') return;
     }
@@ -598,6 +603,32 @@ export class WSGateway implements WSGatewayPublic {
 
     this.sendCore(client.ws, { id: msg.id, type: 'error', payload: decision.receipt });
     return null;
+  }
+
+  private async canPassRuntimePolicies(
+    clientId: string,
+    client: ConnectedClient,
+    schema: CommandSchema,
+    msg: WSMessage,
+  ): Promise<boolean> {
+    const wsCtx = this.createWSContext(clientId, client);
+    const hookCtx: WSCommandHookContext = {
+      command: msg.type,
+      ctx: wsCtx,
+      msg,
+      cancelled: false,
+    };
+    await this.hooks.runHook('ws.command', hookCtx);
+    if (!hookCtx.cancelled) return true;
+    this.sendCore(client.ws, {
+      id: msg.id,
+      type: 'error',
+      payload: hookCtx.blockReason ?? {
+        error: `Command '${schema.type}' was blocked`,
+        code: 'COMMAND_BLOCKED',
+      },
+    });
+    return false;
   }
 
   private async dispatchDomainVenueRequest(

--- a/packages/server/src/core/server/ws-gateway.ts
+++ b/packages/server/src/core/server/ws-gateway.ts
@@ -19,6 +19,7 @@ import { nanoid } from 'nanoid';
 import type { CommandSchema, HookRegistry, WSContext, WSGatewayPublic, WSDispatchResult } from '../plugin-system/hook-registry.js';
 import type { ServiceRegistry } from '../plugin-system/service-registry.js';
 import type { AuthService } from '../auth/service.js';
+import type { PermissionCredential } from '../permission/service.js';
 import type { AgentSession, WSMessage } from '../../types/index.js';
 import { getCookieAuthUser, verifyToken } from './middleware.js';
 import { AgentSessionService, type AgentSessionSnapshot } from './agent-session-service.js';
@@ -303,6 +304,7 @@ export class WSGateway implements WSGatewayPublic {
     }
 
     const schema = this.hooks.getWSCommandSchema(msg.type);
+    let permissionCredentials: PermissionCredential[] = [];
     if (schema) {
       const requiresController = schema.controlPolicy?.controllerRequired ?? true;
       if (requiresController) {
@@ -332,6 +334,10 @@ export class WSGateway implements WSGatewayPublic {
 
       const canExecute = await this.canExecuteVenueRequest(client, schema, msg);
       if (!canExecute) return;
+      permissionCredentials = canExecute.credentials;
+
+      const domainDispatch = await this.dispatchDomainVenueRequest(client, schema, msg, permissionCredentials);
+      if (domainDispatch !== 'skipped') return;
     }
 
     const sessionStateBefore = client.session
@@ -559,12 +565,16 @@ export class WSGateway implements WSGatewayPublic {
     return false;
   }
 
-  private async canExecuteVenueRequest(client: ConnectedClient, schema: CommandSchema, msg: WSMessage): Promise<boolean> {
-    if (!client.session) return false;
-    if (!schema.pluginName || schema.pluginName === 'core') return true;
+  private async canExecuteVenueRequest(
+    client: ConnectedClient,
+    schema: CommandSchema,
+    msg: WSMessage,
+  ): Promise<{ credentials: PermissionCredential[] } | null> {
+    if (!client.session) return null;
+    if (!schema.pluginName || schema.pluginName === 'core') return { credentials: [] };
 
     const requiredCapabilities = schema.protocol?.request?.requiredCapabilities ?? [];
-    if (requiredCapabilities.length === 0) return true;
+    if (requiredCapabilities.length === 0) return { credentials: [] };
 
     const permissions = this.services.tryGet('permission');
     if (!permissions) {
@@ -580,14 +590,40 @@ export class WSGateway implements WSGatewayPublic {
           details: { command: msg.type },
         },
       });
-      return false;
+      return null;
     }
 
     const decision = await permissions.canExecute(client.session, schema);
-    if (decision.status === 'allow') return true;
+    if (decision.status === 'allow') return { credentials: decision.credentials };
 
     this.sendCore(client.ws, { id: msg.id, type: 'error', payload: decision.receipt });
-    return false;
+    return null;
+  }
+
+  private async dispatchDomainVenueRequest(
+    client: ConnectedClient,
+    schema: CommandSchema,
+    msg: WSMessage,
+    permissionCredentials: PermissionCredential[],
+  ): Promise<'handled' | 'skipped'> {
+    if (!client.session) return 'handled';
+    const domainDispatch = this.services.tryGet('domain-dispatch');
+    if (!domainDispatch) return 'skipped';
+
+    const result = await domainDispatch.dispatchVenueRequest({
+      schema,
+      msg,
+      session: client.session,
+      permissionCredentials,
+    });
+    if (result.status === 'skipped') return 'skipped';
+
+    this.sendCore(client.ws, {
+      id: msg.id,
+      type: result.receipt.ok ? 'result' : 'error',
+      payload: result.receipt,
+    });
+    return 'handled';
   }
 
   private buildSessionState(agentId: string, connectionId: string): AgentSessionSnapshot {

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -11,6 +11,7 @@ import { PluginPlatformHost } from './core/plugin-platform/host.js';
 
 import { AuthService } from './core/auth/service.js';
 import { PermissionCredentialService } from './core/permission/service.js';
+import { DomainDispatchService } from './core/domain/dispatch.js';
 import { LogService } from './core/logger/service.js';
 import { registerAuthRoutes } from './core/auth/auth-routes.js';
 import { registerDashboardRoutes } from './core/auth/dashboard-routes.js';
@@ -75,6 +76,11 @@ export async function runMain() {
     packageRoot: getPackageRoot(),
     pluginStoreDir: getPluginStoreDir(),
   });
+  const domainDispatch = new DomainDispatchService(db, {
+    cityId: process.env.URUC_CITY_ID ?? 'uruc.city.local',
+    pluginPlatform: loader,
+  });
+  services.register('domain-dispatch', domainDispatch);
 
   await loader.startAll({ db, services, hooks });
 


### PR DESCRIPTION
Closes #11

## Implementation
- Adds `DomainDispatchService` for signed City -> Domain envelopes after WSGateway action lease and permission checks pass.
- Extends Domain Document/attachment storage with optional dispatch endpoint and Domain public keys for signed receipt verification.
- Adds `domain_dispatch_audits` with pre-dispatch envelope hash/body and final compact receipt.
- Keeps local topology on the existing local handler; domain topology without an active attachment returns a stable compact failure and does not fake success.

## Checks
- `npm run test --workspace=packages/server -- src/core/domain/__tests__/domain-attachment.test.ts src/core/domain/__tests__/domain-dispatch.test.ts src/core/server/__tests__/ws-gateway-permission.test.ts`
- `npm run docs:check`
- `npm run build --workspace=packages/server`
- `git diff --check`

## Out of scope
- No federation or cross-city trust policy; that remains #12.
- No Venue business synchronization protocol. Domain receives a signed envelope and returns a signed receipt/event reference only.
- No bypass around City Core action lease, permission, or policy checks.

## #12
This lands the signed dispatch path needed before #12 can define federation trust/governance skeletons.