### PR TITLE
docs/build: add protocol v1 smoke verification report

### DIFF
--- a/docs/uruc-protocol-v1-smoke-report.md
+++ b/docs/uruc-protocol-v1-smoke-report.md
@@ -1,0 +1,116 @@
+[English](uruc-protocol-v1-smoke-report.md) | [中文](uruc-protocol-v1-smoke-report.zh-CN.md)
+
+# Uruc Protocol v1 Smoke Verification Report
+
+Verification date: 2026-05-03 (Asia/Shanghai)
+
+Verification base commit: `5e8160feb907c366cde7d23cbb9d407094861d38`
+
+Working branch: `codex/protocol-v1-smoke-report`
+
+This report records a bounded smoke verification of the Uruc Protocol v1
+baseline after PR #36 merged the protocol status documents. It uses existing
+targeted tests and existing smoke scripts. It does not start the open #32 or #33
+federation hardening work.
+
+## Checks Run
+
+| Check | Result |
+| --- | --- |
+| `npm run test --workspace=@uruc/server -- src/core/server/__tests__/ws-gateway-action-lease.test.ts src/core/server/__tests__/ws-gateway-permission.test.ts src/core/domain/__tests__/domain-attachment.test.ts src/core/domain/__tests__/domain-dispatch.test.ts src/core/federation/__tests__/federation-policy.test.ts src/core/protocol/__tests__/protocol-conformance.test.ts` | Passed: 6 files, 54 tests |
+| `npm run uruc:smoke` | Passed |
+| `npm run check:bounded` | Passed after serializing concurrent server package builds in `packages/server/scripts/build-package.mjs` |
+| `npm run docs:check` | Passed |
+| `git diff --check` | Passed |
+
+## Verified Items
+
+### Resident Session and City Entry
+
+Covered by `ws-gateway-action-lease.test.ts` and
+`ws-gateway-permission.test.ts`.
+
+The tests authenticate regular, shadow, and principal-backed resident sessions,
+then execute `enter_city`. The verified result shape is a WebSocket `result`
+receipt, including cases where existing regular agent and shadow resident city
+commands remain runnable without venue capability metadata.
+
+### Action Lease
+
+Covered by `ws-gateway-action-lease.test.ts`.
+
+The tests verify that the first write command auto-acquires the same-resident
+action lease, that a second same-resident writer is rejected with
+`ACTION_LEASE_HELD`, and that the response points at `acquire_action_lease`.
+They also verify lease recovery, previous-holder notification, read-only command
+behavior, command discovery, non-holder release rejection, and replacement
+pushes carrying `citytime`.
+
+### Permission Credential and Permission-Required Receipt
+
+Covered by `ws-gateway-permission.test.ts`.
+
+The tests verify active city-issued credentials for shadow and regular resident
+sessions, approved capability dispatch, principal-backed approval dispatch,
+expired approval rejection, and approval-forbidden denial. Missing capability
+checks are verified before venue dispatch and return compact error receipts with
+stable `code`, `text`, `nextAction`, and `details`, including
+`PERMISSION_REQUIRED` with `nextAction: require_approval` and
+`PERMISSION_DENIED` with `nextAction: deny`.
+
+### Local Venue Module Request
+
+Covered by `domain-dispatch.test.ts` and `ws-gateway-permission.test.ts`.
+
+The local topology fixture registers `acme.local.echo@v1`, executes the request,
+calls the local handler once, returns a compact `result` payload
+`{ local: true }`, and records no domain dispatch audit rows. Permission fixture
+requests also verify local venue dispatch with and without declared required
+capabilities.
+
+### Domain Topology, Attachment, and Signed Dispatch
+
+Covered by `domain-attachment.test.ts` and `domain-dispatch.test.ts`.
+
+The tests verify Domain Document validation, attachment receipt storage, attached
+domain dispatch after City Core permission checks, signed City-to-Domain
+envelopes, signed Domain receipt verification, semantic receipt mismatch
+rejection, failed receipt auditing, and the local-topology boundary. No new
+domain system or live external Domain Service was invented for this smoke.
+
+### Audit, Receipt, Error Code, and NextAction Shape
+
+Covered by `ws-gateway-action-lease.test.ts`,
+`ws-gateway-permission.test.ts`, `domain-dispatch.test.ts`, and
+`protocol-conformance.test.ts`.
+
+The targeted tests verify stable action-lease codes, permission-required and
+permission-denied receipts, compact domain dispatch success and failure receipts,
+domain dispatch audit rows, protocol conformance checks, and the current
+`nextAction` migration shape.
+
+### Federation
+
+Covered by `federation-policy.test.ts` and `protocol-conformance.test.ts`.
+
+No live federation network verification was run. The current smoke boundary is
+the existing parser, signature validation, bounded fetch/cache diagnostics,
+expiry, trust-policy, policy-ref, feed-entry, risk, and conformance tests. The
+tests also verify that federation policy results attach to verification output
+without deleting or rewriting resident identity.
+
+## Live Verification Boundaries
+
+- No live federation network verification was performed.
+- No real deployed Uruc instance was used.
+- No new fixture system was created for #32 or #33.
+- `npm run uruc:smoke` verifies local quickstart configuration preservation,
+  bounded server startup, health, doctor plugin checks, and shutdown. It does
+  not itself execute `enter_city`; city-entry behavior is covered by the targeted
+  WebSocket tests listed above.
+
+## Follow-Up
+
+- #32: verify federation policy reference integrity before trust evaluation.
+- #33: verify federation risk and conformance feeds with compact trust results.
+- Run a real deployment smoke after the v1 release candidate is deployed.

--- a/docs/uruc-protocol-v1-smoke-report.zh-CN.md
+++ b/docs/uruc-protocol-v1-smoke-report.zh-CN.md
@@ -1,0 +1,106 @@
+[English](uruc-protocol-v1-smoke-report.md) | [中文](uruc-protocol-v1-smoke-report.zh-CN.md)
+
+# Uruc Protocol v1 Smoke 验证报告
+
+验证日期：2026-05-03（Asia/Shanghai）
+
+验证 base commit：`5e8160feb907c366cde7d23cbb9d407094861d38`
+
+工作分支：`codex/protocol-v1-smoke-report`
+
+本文记录 PR #36 合并 protocol status 文档之后，对 Uruc Protocol v1 baseline
+做的一次 bounded smoke 验证。验证使用已有 targeted tests 和已有 smoke script。本文没有开始
+#32 或 #33 中仍 open 的 federation hardening 工作。
+
+## 已运行检查
+
+| Check | Result |
+| --- | --- |
+| `npm run test --workspace=@uruc/server -- src/core/server/__tests__/ws-gateway-action-lease.test.ts src/core/server/__tests__/ws-gateway-permission.test.ts src/core/domain/__tests__/domain-attachment.test.ts src/core/domain/__tests__/domain-dispatch.test.ts src/core/federation/__tests__/federation-policy.test.ts src/core/protocol/__tests__/protocol-conformance.test.ts` | 通过：6 个文件，54 个 tests |
+| `npm run uruc:smoke` | 通过 |
+| `npm run check:bounded` | 通过；运行中发现并修复了 server package 并发 build 共享 `dist` 的竞态，修复位置是 `packages/server/scripts/build-package.mjs` |
+| `npm run docs:check` | 通过 |
+| `git diff --check` | 通过 |
+
+## 验证项目
+
+### Resident Session 和进入城市
+
+由 `ws-gateway-action-lease.test.ts` 和 `ws-gateway-permission.test.ts` 覆盖。
+
+测试会认证 regular、shadow 和 principal-backed resident sessions，然后执行
+`enter_city`。已验证的返回形态是 WebSocket `result` receipt；同时覆盖了现有 regular
+agent 和 shadow resident city commands 在没有 venue capability metadata 时仍可运行。
+
+### Action Lease
+
+由 `ws-gateway-action-lease.test.ts` 覆盖。
+
+测试验证 first write command 会自动取得 same-resident action lease；第二个
+same-resident writer 会以 `ACTION_LEASE_HELD` 被拒绝，并指向
+`acquire_action_lease`。测试还覆盖 lease recovery、previous-holder notification、
+read-only command behavior、command discovery、非 holder release rejection，以及带有
+`citytime` 的 replacement push。
+
+### Permission Credential 和 Permission-Required Receipt
+
+由 `ws-gateway-permission.test.ts` 覆盖。
+
+测试验证 shadow 和 regular resident sessions 的 active city-issued credentials、
+approved capability dispatch、principal-backed approval dispatch、expired approval
+rejection，以及 approval-forbidden denial。缺失 capability 时会在 venue dispatch 前被拦截，
+并返回 compact error receipt，包含稳定的 `code`、`text`、`nextAction` 和
+`details`，包括 `PERMISSION_REQUIRED` with `nextAction: require_approval`，以及
+`PERMISSION_DENIED` with `nextAction: deny`。
+
+### Local Venue Module Request
+
+由 `domain-dispatch.test.ts` 和 `ws-gateway-permission.test.ts` 覆盖。
+
+local topology fixture 注册 `acme.local.echo@v1`，执行 request，确认 local handler
+被调用一次，返回 compact `result` payload `{ local: true }`，并且没有写入 domain
+dispatch audit rows。permission fixture requests 也验证了带 required capabilities 和不带
+required capabilities 的 local venue dispatch。
+
+### Domain Topology、Attachment 和 Signed Dispatch
+
+由 `domain-attachment.test.ts` 和 `domain-dispatch.test.ts` 覆盖。
+
+测试验证 Domain Document validation、attachment receipt storage、City Core 完成 permission
+checks 之后的 attached domain dispatch、signed City-to-Domain envelope、signed Domain
+receipt verification、semantic receipt mismatch rejection、failed receipt auditing，以及
+local-topology boundary。本次 smoke 没有临时发明新的 domain system，也没有访问 live external
+Domain Service。
+
+### Audit、Receipt、Error Code 和 NextAction 形态
+
+由 `ws-gateway-action-lease.test.ts`、`ws-gateway-permission.test.ts`、
+`domain-dispatch.test.ts` 和 `protocol-conformance.test.ts` 覆盖。
+
+targeted tests 验证 stable action-lease codes、permission-required 和 permission-denied
+receipts、compact domain dispatch success/failure receipts、domain dispatch audit rows、
+protocol conformance checks，以及当前 `nextAction` migration shape。
+
+### Federation
+
+由 `federation-policy.test.ts` 和 `protocol-conformance.test.ts` 覆盖。
+
+没有运行 live federation network verification。当前 smoke 边界是现有 parser、signature
+validation、bounded fetch/cache diagnostics、expiry、trust-policy、policy-ref、feed-entry、
+risk 和 conformance tests。测试也验证 federation policy results 可以附加到 verification
+output，而不会删除或改写 resident identity。
+
+## Live 验证边界
+
+- 未执行 live federation network verification。
+- 未使用真实部署的 Uruc instance。
+- 未为 #32 或 #33 创建新的 fixture system。
+- `npm run uruc:smoke` 验证 local quickstart configuration preservation、bounded server
+  startup、health、doctor plugin checks 和 shutdown。它本身不执行 `enter_city`；
+  city-entry behavior 由上面列出的 targeted WebSocket tests 覆盖。
+
+## Follow-Up
+
+- #32：verify federation policy reference integrity before trust evaluation。
+- #33：verify federation risk and conformance feeds with compact trust results。
+- v1 release candidate 部署后，运行真实部署 smoke。

--- a/packages/server/scripts/build-package.mjs
+++ b/packages/server/scripts/build-package.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 
-import { rm } from 'fs/promises';
+import { mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import path from 'path';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import os from 'os';
+import { createHash } from 'crypto';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(scriptDir, '..');
 const repoRoot = path.resolve(packageRoot, '..', '..');
+const lockId = createHash('sha256').update(packageRoot).digest('hex').slice(0, 16);
+const lockDir = path.join(os.tmpdir(), `uruc-server-build-${lockId}.lock`);
+const staleLockMs = 5 * 60 * 1000;
+const ownerWriteGraceMs = 5_000;
+const pollMs = 100;
 const tscExecutable = path.join(
   repoRoot,
   'node_modules',
@@ -15,14 +22,83 @@ const tscExecutable = path.join(
   process.platform === 'win32' ? 'tsc.cmd' : 'tsc',
 );
 
-await rm(path.join(packageRoot, 'dist'), { recursive: true, force: true });
-execFileSync(tscExecutable, [], {
-  cwd: packageRoot,
-  env: process.env,
-  stdio: 'inherit',
-});
-execFileSync(process.execPath, [path.join(packageRoot, 'scripts', 'copy-plugin-manifests.mjs')], {
-  cwd: packageRoot,
-  env: process.env,
-  stdio: 'inherit',
-});
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+}
+
+function parseOwner(content) {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+async function acquireBuildLock() {
+  while (true) {
+    try {
+      await mkdir(lockDir, { mode: 0o700 });
+      await writeFile(path.join(lockDir, 'owner.json'), `${JSON.stringify({
+        pid: process.pid,
+        packageRoot,
+        createdAt: new Date().toISOString(),
+      })}\n`);
+      return async () => {
+        await rm(lockDir, { recursive: true, force: true });
+      };
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+
+    try {
+      const current = await stat(lockDir);
+      const ageMs = Date.now() - current.mtimeMs;
+      const ownerText = await readFile(path.join(lockDir, 'owner.json'), 'utf8').catch(() => '');
+      const owner = ownerText ? parseOwner(ownerText) : null;
+      const ownerMatchesPackage = owner?.packageRoot === packageRoot;
+      const ownerIsAlive = ownerMatchesPackage && isProcessAlive(owner.pid);
+      const ownerMissingAfterGrace = !owner && ageMs > ownerWriteGraceMs;
+      const ownerDead = ownerMatchesPackage && !ownerIsAlive;
+      const ownerStale = ageMs > staleLockMs;
+
+      if (ownerMissingAfterGrace || ownerDead || ownerStale) {
+        await rm(lockDir, { recursive: true, force: true });
+        console.warn(`Removed stale server build lock${ownerText ? `: ${ownerText.trim()}` : ''}`);
+        continue;
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      continue;
+    }
+
+    await sleep(pollMs);
+  }
+}
+
+const releaseBuildLock = await acquireBuildLock();
+
+try {
+  await rm(path.join(packageRoot, 'dist'), { recursive: true, force: true });
+  execFileSync(tscExecutable, [], {
+    cwd: packageRoot,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  execFileSync(process.execPath, [path.join(packageRoot, 'scripts', 'copy-plugin-manifests.mjs')], {
+    cwd: packageRoot,
+    env: process.env,
+    stdio: 'inherit',
+  });
+} finally {
+  await releaseBuildLock();
+}


### PR DESCRIPTION
## Summary

- add English and Chinese Uruc Protocol v1 smoke verification reports
- record bounded protocol checks, live verification boundaries, and #32/#33 follow-ups
- serialize server package builds so the bounded full-suite package dry-run can pass under parallel tests
- harden the build lock so dead owner processes do not block later bounded builds until timeout

## Checks

- node --check packages/server/scripts/build-package.mjs
- npm run check:bounded
- npm run docs:check
- git diff --check

## Review notes

- PR remote file blobs were compared against local intended content; file content matches despite different commit SHAs from API publishing.
- No #32/#33 federation hardening work is included.
- No live federation network verification is claimed.