### PR TITLE
[codex] Add live permission-required social fixture

### DIFF
--- a/docs/uruc-protocol-v1-real-run-report.md
+++ b/docs/uruc-protocol-v1-real-run-report.md
@@ -158,6 +158,16 @@ A direct WebSocket probe captured the raw error envelope:
 This verifies the compact receipt shape for `error`, `text`, stable `code`,
 `action`, `nextAction`, and `details` on the current live local path.
 
+Follow-up verification on 2026-05-04: the local smoke script now exercises the
+bundled `uruc.social.get_private_profile@v1` permission-required fixture. The
+script logs in through real HTTP auth, creates a dashboard resident, discovers
+the command over WebSocket, verifies
+`protocol.request.requiredCapabilities: ["uruc.social.private-profile.read@v1"]`,
+captures the denied `PERMISSION_REQUIRED` / `require_approval` receipt, creates
+a dashboard permission approval, verifies the returned active `uruc.city`
+credential for the resident and capability, then reruns the command and verifies
+the granted receipt describes the same resident.
+
 ## Web Smoke
 
 A minimal web smoke was run against the same local city:

--- a/docs/uruc-protocol-v1-real-run-report.zh-CN.md
+++ b/docs/uruc-protocol-v1-real-run-report.zh-CN.md
@@ -144,6 +144,14 @@ Permission policy denies this request.
 这验证了当前 live local path 上 `error`、`text`、stable `code`、`action`、`nextAction` 和
 `details` 的紧凑 receipt 形态。
 
+2026-05-04 后续验证：本地 smoke 脚本现在会执行 bundled
+`uruc.social.get_private_profile@v1` permission-required fixture。脚本通过真实 HTTP auth 登录，经
+dashboard 创建 resident，通过 WebSocket discovery 发现该命令，验证
+`protocol.request.requiredCapabilities: ["uruc.social.private-profile.read@v1"]`，捕获 denied
+`PERMISSION_REQUIRED` / `require_approval` receipt，创建 dashboard permission approval，验证返回的是该
+resident 与 capability 对应的 active `uruc.city` credential，然后再次执行命令并验证 granted receipt 描述的是同一个
+resident。
+
 ## Web Smoke
 
 同一座本地 city 上执行了最小 web smoke：

--- a/packages/plugins/social/GUIDE.md
+++ b/packages/plugins/social/GUIDE.md
@@ -158,6 +158,7 @@ Once a thread exists, messaging is always based on `threadId`.
 | `social_intro` | none | Return a compact agent-first intro and recommended first commands | Best first call for an unfamiliar agent discovered through `what_can_i_do` |
 | `get_usage_guide` | none | Return the full social plugin usage guide, rules, and recommended commands | Use when the compact intro is not enough |
 | `get_privacy_status` | none | Return privacy and retention status for the current social subject | Read-only |
+| `get_private_profile` | `uruc.social.private-profile.read@v1` | Return the current social subject's privacy-sensitive profile and retention status | Requires explicit permission approval |
 | `request_data_export` | none | Export the current social subject data as JSON | Exports the current subject, not one thread |
 | `request_data_erasure` | none | Erase the current social subject data | Erases current subject data, not just one conversation |
 | `search_contacts` | `query`, `limit`, `viewerAgentId?` | Search discoverable agents by agent ID, name, or description and return relationship state | `viewerAgentId` is for owner watch mode |
@@ -197,6 +198,7 @@ Read commands:
 - `social_intro`
 - `get_usage_guide`
 - `get_privacy_status`
+- `get_private_profile`
 - `search_contacts`
 - `list_relationships_page`
 - `list_relationships`

--- a/packages/plugins/social/GUIDE.zh-CN.md
+++ b/packages/plugins/social/GUIDE.zh-CN.md
@@ -165,6 +165,7 @@ Web 前端当前主要有三个区域：
 | `social_intro` | 无 | 返回精简的 agent-first 入口说明和推荐起步命令 | 通过 `what_can_i_do` 发现后的第一条命令 |
 | `get_usage_guide` | 无 | 返回完整社交插件用法、规则与推荐命令 | 精简 intro 不够时再调用 |
 | `get_privacy_status` | 无 | 返回当前社交主体的隐私与保留状态 | 读命令 |
+| `get_private_profile` | `uruc.social.private-profile.read@v1` | 返回当前社交主体的隐私敏感资料与保留状态 | 需要显式 permission approval |
 | `request_data_export` | 无 | 导出当前社交主体数据 | 导出的是当前主体，不是单个聊天窗口 |
 | `request_data_erasure` | 无 | 删除当前社交主体数据 | 删除的是当前主体，不是只清空一条会话 |
 | `search_contacts` | `query`, `limit`, `viewerAgentId?` | 按 agent ID、名字或描述搜索可发现 agent，并带关系状态 | `viewerAgentId` 用于主人监视视角 |
@@ -204,6 +205,7 @@ Web 前端当前主要有三个区域：
 - `social_intro`
 - `get_usage_guide`
 - `get_privacy_status`
+- `get_private_profile`
 - `search_contacts`
 - `list_relationships_page`
 - `list_relationships`

--- a/packages/plugins/social/README.md
+++ b/packages/plugins/social/README.md
@@ -48,6 +48,7 @@ WebSocket commands:
 - `uruc.social.social_intro@v1`
 - `uruc.social.get_usage_guide@v1`
 - `uruc.social.get_privacy_status@v1`
+- `uruc.social.get_private_profile@v1`
 - `uruc.social.request_data_export@v1`
 - `uruc.social.request_data_erasure@v1`
 - `uruc.social.search_contacts@v1`

--- a/packages/plugins/social/README.zh-CN.md
+++ b/packages/plugins/social/README.zh-CN.md
@@ -48,6 +48,7 @@ WebSocket 命令：
 - `uruc.social.social_intro@v1`
 - `uruc.social.get_usage_guide@v1`
 - `uruc.social.get_privacy_status@v1`
+- `uruc.social.get_private_profile@v1`
 - `uruc.social.request_data_export@v1`
 - `uruc.social.request_data_erasure@v1`
 - `uruc.social.search_contacts@v1`

--- a/packages/plugins/social/index.mjs
+++ b/packages/plugins/social/index.mjs
@@ -2,6 +2,9 @@ import { defineBackendPlugin } from '@uruc/plugin-sdk/backend';
 import { SocialService, createSocialAssetDir, createSocialExportDir, parseMomentUpload } from './service.mjs';
 
 const PLUGIN_ID = 'uruc.social';
+const PRIVATE_PROFILE_CAPABILITY = 'uruc.social.private-profile.read@v1';
+const PRIVATE_PROFILE_REQUEST_TYPE = 'uruc.social.private-profile.read.request@v1';
+const PRIVATE_PROFILE_RECEIPT_TYPE = 'uruc.social.private-profile.read.receipt@v1';
 
 function requireSession(runtimeCtx) {
   if (!runtimeCtx.session) {
@@ -138,6 +141,27 @@ export default defineBackendPlugin({
       inputSchema: {},
       locationPolicy: readAnywhere,
       actionLeasePolicy: readPolicy,
+      handler: async (_input, runtimeCtx) => service.getPrivacyStatus(requireSession(runtimeCtx)),
+    });
+
+    await ctx.commands.register({
+      id: 'get_private_profile',
+      description: 'Show privacy-sensitive profile and retention status after explicit permission approval.',
+      inputSchema: {},
+      locationPolicy: readAnywhere,
+      actionLeasePolicy: readPolicy,
+      protocol: {
+        subject: 'resident',
+        request: {
+          type: PRIVATE_PROFILE_REQUEST_TYPE,
+          requiredCapabilities: [PRIVATE_PROFILE_CAPABILITY],
+        },
+        receipt: {
+          type: PRIVATE_PROFILE_RECEIPT_TYPE,
+          statuses: ['accepted', 'require_approval'],
+        },
+        venue: { id: PLUGIN_ID },
+      },
       handler: async (_input, runtimeCtx) => service.getPrivacyStatus(requireSession(runtimeCtx)),
     });
 

--- a/packages/server/src/core/plugin-platform/__tests__/host.test.ts
+++ b/packages/server/src/core/plugin-platform/__tests__/host.test.ts
@@ -11,9 +11,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
 
 import { createDb } from '../../database/index.js';
+import { AuthService } from '../../auth/service.js';
+import { PermissionCredentialService } from '../../permission/service.js';
 import { registerCityCommands } from '../../city/commands.js';
 import { HookRegistry } from '../../plugin-system/hook-registry.js';
 import { ServiceRegistry } from '../../plugin-system/service-registry.js';
+import { WSGateway } from '../../server/ws-gateway.js';
 import { PluginPlatformHost } from '../host.js';
 import { readCityLock, writeCityConfig, writeCityLock } from '../config.js';
 
@@ -181,6 +184,24 @@ function createGateway(sent: unknown[], agentPushes: Array<{ agentId: string; me
       return [];
     },
   };
+}
+
+function createGatewayClient(sent: unknown[]) {
+  return {
+    id: `client-${Math.random().toString(16).slice(2)}`,
+    ws: {
+      readyState: 1,
+      send(data: string) {
+        sent.push(JSON.parse(data));
+      },
+      close() {},
+      ping() {},
+      terminate() {},
+    },
+    msgTimestamps: [],
+    isAlive: true,
+    lastPong: Date.now(),
+  } as any;
 }
 
 function createHttpRequest(
@@ -2403,6 +2424,20 @@ export default defineBackendPlugin({
       },
     });
     expect(availableCommands.find((command) => command.type === 'uruc.social.get_usage_guide@v1')).toBeTruthy();
+    expect(availableCommands.find((command) => command.type === 'uruc.social.get_private_profile@v1')).toMatchObject({
+      protocol: {
+        subject: 'resident',
+        request: {
+          type: 'uruc.social.private-profile.read.request@v1',
+          requiredCapabilities: ['uruc.social.private-profile.read@v1'],
+        },
+        receipt: {
+          type: 'uruc.social.private-profile.read.receipt@v1',
+          statuses: ['accepted', 'require_approval'],
+        },
+        venue: { id: 'uruc.social' },
+      },
+    });
     expect(availableCommands.find((command) => command.type === 'uruc.social.request_data_erasure@v1')).toMatchObject({
       confirmationPolicy: {
         required: true,
@@ -2465,6 +2500,86 @@ export default defineBackendPlugin({
             expect.stringContaining('uruc.social.list_relationships@v1'),
           ]),
         }),
+      },
+    });
+
+    await host.stopAll();
+  });
+
+  it('enforces approval before executing the bundled social private profile request', async () => {
+    const socialPluginPath = path.resolve(process.cwd(), '..', 'plugins', 'social');
+    const sent: any[] = [];
+
+    const { host, hooks, db, services } = await startSinglePluginHost(
+      'uruc.social',
+      '@uruc/plugin-social',
+      socialPluginPath,
+    );
+
+    const auth = new AuthService(db);
+    const permissions = new PermissionCredentialService(db);
+    const gateway = new WSGateway({ port: 0 }, hooks, services, auth);
+    services.register('permission', permissions);
+    services.register('ws-gateway', gateway as any);
+
+    db.run(sql`
+      INSERT INTO users (id, username, password_hash, email, role, banned, email_verified, created_at)
+      VALUES ('user-social-permission', 'socialpermission', 'hash', 'social-permission@example.com', 'user', 0, 1, ${Date.now()})
+    `);
+    const agent = await auth.createAgent('user-social-permission', 'Social Permission Agent');
+
+    const client = createGatewayClient(sent);
+    (gateway as any).clients.set('client-social-permission', client);
+    await (gateway as any).handleAgentAuth('client-social-permission', client, {
+      id: 'auth-social-permission',
+      type: 'auth',
+      payload: agent.token,
+    });
+
+    sent.length = 0;
+    await (gateway as any).handleMessage('client-social-permission', {
+      id: 'private-profile-denied',
+      type: 'uruc.social.get_private_profile@v1',
+      payload: {},
+    });
+
+    expect(sent.at(-1)).toMatchObject({
+      id: 'private-profile-denied',
+      type: 'error',
+      payload: {
+        code: 'PERMISSION_REQUIRED',
+        text: 'Permission required for this request.',
+        nextAction: 'require_approval',
+        details: {
+          requestType: 'uruc.social.private-profile.read.request@v1',
+          requiredCapabilities: ['uruc.social.private-profile.read@v1'],
+          missingCapabilities: ['uruc.social.private-profile.read@v1'],
+        },
+      },
+    });
+
+    await permissions.approveCredential({
+      authorityUserId: 'user-social-permission',
+      residentId: agent.id,
+      capabilities: ['uruc.social.private-profile.read@v1'],
+    });
+
+    sent.length = 0;
+    await (gateway as any).handleMessage('client-social-permission', {
+      id: 'private-profile-granted',
+      type: 'uruc.social.get_private_profile@v1',
+      payload: {},
+    });
+
+    expect(sent.at(-1)).toMatchObject({
+      id: 'private-profile-granted',
+      type: 'result',
+      payload: {
+        subject: {
+          agentId: agent.id,
+          agentName: 'Social Permission Agent',
+        },
+        retention: expect.any(Object),
       },
     });
 

--- a/scripts/verify-uruc-local-smoke.mjs
+++ b/scripts/verify-uruc-local-smoke.mjs
@@ -205,6 +205,24 @@ function assertGrantedReceipt(envelope, agentId) {
   }
 }
 
+function assertApprovalCredential(payload, agentId) {
+  const credential = payload.credential;
+  if (
+    credential?.residentId !== agentId
+    || credential?.issuerId !== 'uruc.city'
+    || credential?.status !== 'active'
+    || !credential.capabilities?.includes(permissionSmoke.capability)
+  ) {
+    throw new Error(`Dashboard approval returned unexpected credential: ${JSON.stringify(payload)}`);
+  }
+  if (!credential.validUntil || Number.isNaN(new Date(credential.validUntil).getTime())) {
+    throw new Error(`Dashboard approval did not return an expiring credential: ${JSON.stringify(payload)}`);
+  }
+  if (new Date(credential.validUntil).getTime() <= Date.now()) {
+    throw new Error(`Dashboard approval credential is already expired: ${JSON.stringify(payload)}`);
+  }
+}
+
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-local-smoke-'));
 const envPath = path.join(tempRoot, 'server.env');
 const stateDir = path.join(tempRoot, 'state');
@@ -328,10 +346,11 @@ try {
     });
     assertPermissionRequiredReceipt(denied);
 
-    await postJson(`${baseUrl}/api/dashboard/permission-approvals`, {
+    const approval = await postJson(`${baseUrl}/api/dashboard/permission-approvals`, {
       residentId: agent.id,
       capabilities: [permissionSmoke.capability],
     }, { cookie });
+    assertApprovalCredential(approval.payload, agent.id);
 
     const granted = await sendWsMessage(ws, {
       id: 'permission-smoke-granted',

--- a/scripts/verify-uruc-local-smoke.mjs
+++ b/scripts/verify-uruc-local-smoke.mjs
@@ -7,10 +7,16 @@ import net from 'node:net';
 import { spawnSync } from 'node:child_process';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import WebSocket from 'ws';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const urucEntrypoint = path.join(repoRoot, 'uruc');
+const permissionSmoke = {
+  command: 'uruc.social.get_private_profile@v1',
+  capability: 'uruc.social.private-profile.read@v1',
+  requestType: 'uruc.social.private-profile.read.request@v1',
+};
 
 function parseEnv(content) {
   const env = {};
@@ -83,6 +89,120 @@ async function waitForHealth(url, timeoutMs = 30000) {
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
   throw new Error(`Timed out waiting for health endpoint: ${url}`);
+}
+
+async function postJson(url, body, options = {}) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.cookie ? { Cookie: options.cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`POST ${url} failed with ${response.status}: ${JSON.stringify(payload)}`);
+  }
+  return { response, payload };
+}
+
+function extractCookieHeader(response) {
+  const setCookies = typeof response.headers.getSetCookie === 'function'
+    ? response.headers.getSetCookie()
+    : [response.headers.get('set-cookie')].filter(Boolean);
+  const cookie = setCookies.map((value) => value.split(';')[0]).filter(Boolean).join('; ');
+  if (!cookie) throw new Error('Login response did not include a session cookie');
+  return cookie;
+}
+
+async function withWebSocket(url, callback) {
+  const ws = new WebSocket(url);
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+
+  try {
+    return await callback(ws);
+  } finally {
+    ws.close();
+  }
+}
+
+async function sendWsMessage(ws, message) {
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for WebSocket response to ${message.id}`));
+    }, 10000);
+    const onMessage = (data) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(data.toString());
+      } catch (error) {
+        cleanup();
+        reject(error);
+        return;
+      }
+      if (parsed.id !== message.id) return;
+      cleanup();
+      resolve(parsed);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+    };
+    ws.on('message', onMessage);
+    ws.on('error', onError);
+    ws.send(JSON.stringify(message));
+  });
+}
+
+function assertPermissionSmokeDiscovery(payload) {
+  const command = payload.commands?.find((item) => item.type === permissionSmoke.command);
+  if (!command) {
+    throw new Error(`Discovery did not expose ${permissionSmoke.command}`);
+  }
+  const requiredCapabilities = command.protocol?.request?.requiredCapabilities ?? [];
+  if (!requiredCapabilities.includes(permissionSmoke.capability)) {
+    throw new Error(`Discovery did not expose required capability ${permissionSmoke.capability}: ${JSON.stringify(command)}`);
+  }
+  if (command.protocol?.request?.type !== permissionSmoke.requestType) {
+    throw new Error(`Discovery exposed unexpected request type: ${JSON.stringify(command.protocol?.request)}`);
+  }
+}
+
+function assertPermissionRequiredReceipt(envelope) {
+  if (envelope.type !== 'error') {
+    throw new Error(`Expected permission-required error envelope, got ${JSON.stringify(envelope)}`);
+  }
+  const payload = envelope.payload ?? {};
+  const details = payload.details ?? {};
+  if (
+    payload.code !== 'PERMISSION_REQUIRED'
+    || payload.text !== 'Permission required for this request.'
+    || payload.nextAction !== 'require_approval'
+    || details.requestType !== permissionSmoke.requestType
+    || !details.requiredCapabilities?.includes(permissionSmoke.capability)
+    || !details.missingCapabilities?.includes(permissionSmoke.capability)
+  ) {
+    throw new Error(`Unexpected permission-required receipt: ${JSON.stringify(envelope)}`);
+  }
+}
+
+function assertGrantedReceipt(envelope, agentId) {
+  if (envelope.type !== 'result') {
+    throw new Error(`Expected granted result envelope, got ${JSON.stringify(envelope)}`);
+  }
+  if (envelope.payload?.subject?.agentId !== agentId) {
+    throw new Error(`Granted result did not describe the smoke resident: ${JSON.stringify(envelope)}`);
+  }
 }
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'uruc-local-smoke-'));
@@ -166,6 +286,60 @@ try {
   if (health.status !== 'ok') {
     throw new Error(`Unexpected health payload: ${JSON.stringify(health)}`);
   }
+
+  const baseUrl = `http://127.0.0.1:${httpPort}`;
+  const login = await postJson(`${baseUrl}/api/auth/login`, {
+    username: 'smoke-admin',
+    password: 'smoke-secret',
+  });
+  const cookie = extractCookieHeader(login.response);
+  const agentResult = await postJson(`${baseUrl}/api/dashboard/agents`, {
+    name: 'permission-smoke-resident',
+  }, { cookie });
+  const agent = agentResult.payload.agent;
+  if (!agent?.id || !agent?.token) {
+    throw new Error(`Dashboard agent creation did not return id and token: ${JSON.stringify(agentResult.payload)}`);
+  }
+
+  await withWebSocket(`ws://127.0.0.1:${wsPort}`, async (ws) => {
+    const auth = await sendWsMessage(ws, {
+      id: 'auth-permission-smoke',
+      type: 'auth',
+      payload: agent.token,
+    });
+    if (auth.type !== 'result' || auth.payload?.agentId !== agent.id) {
+      throw new Error(`WebSocket auth failed for permission smoke resident: ${JSON.stringify(auth)}`);
+    }
+
+    const discovery = await sendWsMessage(ws, {
+      id: 'discover-permission-smoke',
+      type: 'what_can_i_do',
+      payload: { scope: 'plugin', pluginId: 'uruc.social' },
+    });
+    if (discovery.type !== 'result') {
+      throw new Error(`Social command discovery failed: ${JSON.stringify(discovery)}`);
+    }
+    assertPermissionSmokeDiscovery(discovery.payload ?? {});
+
+    const denied = await sendWsMessage(ws, {
+      id: 'permission-smoke-denied',
+      type: permissionSmoke.command,
+      payload: {},
+    });
+    assertPermissionRequiredReceipt(denied);
+
+    await postJson(`${baseUrl}/api/dashboard/permission-approvals`, {
+      residentId: agent.id,
+      capabilities: [permissionSmoke.capability],
+    }, { cookie });
+
+    const granted = await sendWsMessage(ws, {
+      id: 'permission-smoke-granted',
+      type: permissionSmoke.command,
+      payload: {},
+    });
+    assertGrantedReceipt(granted, agent.id);
+  });
 
   const doctor = run(urucEntrypoint, ['doctor', '--json'], { env: baseEnv });
   const doctorReport = JSON.parse(doctor.stdout);


### PR DESCRIPTION
Closes #39

## Summary
- Adds a bundled `uruc.social` permission-required read request for the current resident private profile/retention status.
- Extends the live local smoke script to verify discovery, missing-credential `PERMISSION_REQUIRED`, dashboard approval, and granted execution over real HTTP + WebSocket.
- Documents the new Social command in English and Chinese command guides.

## Fixture
- Venue Module: `uruc.social`
- Command id: `uruc.social.get_private_profile@v1`
- Capability id: `uruc.social.private-profile.read@v1`
- Request type: `uruc.social.private-profile.read.request@v1`

## Denied path
- Without `uruc.social.private-profile.read@v1`, dispatch stops before the Social handler and returns `PERMISSION_REQUIRED` with `text`, `nextAction: require_approval`, and `details.requiredCapabilities/missingCapabilities`.

## Granted path
- `PermissionCredentialService.approveCredential` / `/api/dashboard/permission-approvals` grants `uruc.social.private-profile.read@v1` to the resident.
- The same command then executes and returns the Social private profile/retention payload for that resident.

## Checks
- `npm run test --workspace=@uruc/server -- src/core/plugin-platform/__tests__/host.test.ts src/core/server/__tests__/ws-gateway-permission.test.ts`
- `npm run uruc:smoke`
- `npm run docs:check`
- `npm run build --workspace=packages/server`
- `git diff --check`